### PR TITLE
Setting yAxis for radar Chart crashing on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "react-native-charts-wrapper",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ramki1979/react-native-charts-wrapper.git"
+    "url": "https://github.com/wuxudong/react-native-charts-wrapper.git"
   },
   "version": "0.2.10",
   "description": "A react-native charts support both android and ios.",
   "author": "wuxudong",
   "license": "MIT",
   "nativePackage": true,
-  "homepage": "https://github.com/ramki1979/react-native-charts-wrapper",
+  "homepage": "https://github.com/wuxudong/react-native-charts-wrapper",
   "keywords":  [
     "react native",
     "chart",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "react-native-charts-wrapper",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wuxudong/react-native-charts-wrapper.git"
+    "url": "https://github.com/ramki1979/react-native-charts-wrapper.git"
   },
   "version": "0.2.10",
   "description": "A react-native charts support both android and ios.",
   "author": "wuxudong",
   "license": "MIT",
   "nativePackage": true,
-  "homepage": "https://github.com/wuxudong/react-native-charts-wrapper",
+  "homepage": "https://github.com/ramki1979/react-native-charts-wrapper",
   "keywords":  [
     "react native",
     "chart",


### PR DESCRIPTION
```RNRadarChartView``` didn't override setYAxis method as required by ```RNYAxisChartViewBase```

This pull request just added the missing method on ```RNRadarChartView```
