### PR TITLE
Option to work with date and time formatter on Android and iOS

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -361,6 +361,9 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
                 axis.setValueFormatter(new LargeValueFormatter());
             } else if ("percent".equals(valueFormatter)) {
                 axis.setValueFormatter(new PercentFormatter());
+            } else if ("date".equals(valueFormatter)) {
+                String valueFormatterPattern = propMap.getString("valueFormatterPattern");
+                axis.setValueFormatter(new DateFormatter(valueFormatterPattern));
             } else {
                 axis.setValueFormatter(new CustomFormatter(valueFormatter));
             }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/DateFormatter.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/DateFormatter.java
@@ -1,0 +1,38 @@
+package com.github.wuxudong.rncharts.charts;
+
+import com.github.mikephil.charting.components.AxisBase;
+import com.github.mikephil.charting.data.Entry;
+import com.github.mikephil.charting.formatter.IAxisValueFormatter;
+import com.github.mikephil.charting.formatter.IValueFormatter;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Created by dougl on 05/09/2017.
+ */
+
+public class DateFormatter implements IAxisValueFormatter, IValueFormatter {
+
+    private DateFormat mFormat;
+
+    public DateFormatter(String pattern) {
+        mFormat = new SimpleDateFormat(pattern);
+    }
+
+    @Override
+    public String getFormattedValue(float value, AxisBase yAxis) {
+        return format(value);
+    }
+
+    @Override
+    public String getFormattedValue(float value, Entry entry, int dataSetIndex, ViewPortHandler viewPortHandler) {
+        return format(value);
+    }
+
+    private String format(Number number) {
+        return mFormat.format(new Date((long) number));
+    }
+}

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/DateFormatter.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/DateFormatter.java
@@ -24,15 +24,15 @@ public class DateFormatter implements IAxisValueFormatter, IValueFormatter {
 
     @Override
     public String getFormattedValue(float value, AxisBase yAxis) {
-        return format(value);
+        return format((long) value);
     }
 
     @Override
     public String getFormattedValue(float value, Entry entry, int dataSetIndex, ViewPortHandler viewPortHandler) {
-        return format(value);
+        return format((long) value);
     }
 
-    private String format(Number number) {
-        return mFormat.format(new Date((long) number));
+    private String format(long millis) {
+        return mFormat.format(new Date(millis));
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
@@ -56,6 +56,9 @@ public class ChartDataSetConfigUtils {
                 dataSet.setValueFormatter(new LargeValueFormatter());
             } else if ("percent".equals(valueFormatter)) {
                 dataSet.setValueFormatter(new PercentFormatter());
+            } else if ("date".equals(valueFormatter)) {
+                String valueFormatterPattern = config.getString("valueFormatterPattern");
+                dataSet.setValueFormatter(new DateFormatter(valueFormatterPattern));
             } else {
                 dataSet.setValueFormatter(new CustomFormatter(valueFormatter));
             }

--- a/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
@@ -11,6 +11,7 @@ import com.github.mikephil.charting.data.LineScatterCandleRadarDataSet;
 import com.github.mikephil.charting.formatter.LargeValueFormatter;
 import com.github.mikephil.charting.formatter.PercentFormatter;
 import com.github.wuxudong.rncharts.charts.CustomFormatter;
+import com.github.wuxudong.rncharts.charts.DateFormatter;
 
 /**
  * https://github.com/PhilJay/MPAndroidChart/wiki/The-DataSet-class

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -323,20 +323,24 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         
         // formatting
         // TODO: other formatting options
-        if config["valueFormatter"].array != nil {
-            axis.valueFormatter = IndexAxisValueFormatter(values: config["valueFormatter"].arrayValue.map({ $0.stringValue }))
-        } else if config["valueFormatter"].string != nil {
-            if "largeValue" == config["valueFormatter"].stringValue {
+        let valueFormatter = config["valueFormatter"];
+        if valueFormatter.array != nil {
+            axis.valueFormatter = IndexAxisValueFormatter(values: valueFormatter.arrayValue.map({ $0.stringValue }))
+        } else if valueFormatter.string != nil {
+            if "largeValue" == valueFormatter.stringValue {
                 axis.valueFormatter = LargeValueFormatter();
-            } else if "percent" == config["valueFormatter"].stringValue {
+            } else if "percent" == valueFormatter.stringValue {
                 let percentFormatter = NumberFormatter()
                 percentFormatter.numberStyle = .percent
                 
                 axis.valueFormatter = DefaultAxisValueFormatter(formatter: percentFormatter);
+            } else if "date" == valueFormatter.stringValue {
+              let valueFormatterPattern = config["valueFormatterPattern"].stringValue;
+              axis.valueFormatter = ChartDateFormatter(pattern: valueFormatterPattern);
             } else {
               let customFormatter = NumberFormatter()
-              customFormatter.positiveFormat = config["valueFormatter"].stringValue
-              customFormatter.negativeFormat = config["valueFormatter"].stringValue
+              customFormatter.positiveFormat = valueFormatter.stringValue
+              customFormatter.negativeFormat = valueFormatter.stringValue
               
               axis.valueFormatter = DefaultAxisValueFormatter(formatter: customFormatter);
           }

--- a/ios/ReactNativeCharts/formatters/ChartDateFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/ChartDateFormatter.swift
@@ -1,0 +1,38 @@
+//
+//  DateFormatter.swift
+//  Aquasafe
+//
+//  Created by Douglas Nassif Roma Junior on 06/09/17.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+import Foundation
+import Charts
+
+open class ChartDateFormatter: NSObject, IValueFormatter, IAxisValueFormatter {
+
+  open var dateFormatter = DateFormatter();
+  
+  public override init() {
+    
+  }
+  
+  public init(pattern: String?) {
+    self.dateFormatter.dateFormat = pattern;
+  }
+  
+  open func stringForValue(_ value: Double, axis: AxisBase?) -> String {
+    return format(value)
+  }
+  
+  open func stringForValue(_ value: Double, entry: ChartDataEntry, dataSetIndex: Int, viewPortHandler: ViewPortHandler?) -> String {
+    return format(value)
+  }
+  
+  fileprivate func format(_ value: Double) -> String
+  {
+    let date = Date(timeIntervalSince1970: value);
+    return self.dateFormatter.string(from: date);
+  }
+
+}

--- a/ios/ReactNativeCharts/formatters/ChartDateFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/ChartDateFormatter.swift
@@ -31,7 +31,7 @@ open class ChartDateFormatter: NSObject, IValueFormatter, IAxisValueFormatter {
   
   fileprivate func format(_ value: Double) -> String
   {
-    let date = Date(timeIntervalSince1970: value);
+    let date = Date(timeIntervalSince1970: value / 1000.0);
     return self.dateFormatter.string(from: date);
   }
 

--- a/ios/ReactNativeCharts/utils/ChartDataSetConfigUtils.swift
+++ b/ios/ReactNativeCharts/utils/ChartDataSetConfigUtils.swift
@@ -41,19 +41,23 @@ class ChartDataSetConfigUtils: NSObject {
         if config["visible"].bool != nil {
             dataSet.visible = config["visible"].boolValue
         }
-        
-        if config["valueFormatter"].string != nil {
-            if "largeValue" == config["valueFormatter"].stringValue {
+      
+        let valueFormatter = config["valueFormatter"];
+        if valueFormatter.string != nil {
+            if "largeValue" == valueFormatter.stringValue {
                 dataSet.valueFormatter = LargeValueFormatter();
-            } else if "percent" == config["valueFormatter"].stringValue {
+            } else if "percent" == valueFormatter.stringValue {
                 let percentFormatter = NumberFormatter()
                 percentFormatter.numberStyle = .percent
                 
                 dataSet.valueFormatter = DefaultValueFormatter(formatter: percentFormatter);
+            } else if "date" == valueFormatter.stringValue {
+                let valueFormatterPattern = config["valueFormatterPattern"].stringValue;
+                dataSet.valueFormatter = ChartDateFormatter(pattern: valueFormatterPattern);
             } else {
                 let customFormatter = NumberFormatter()
-                customFormatter.positiveFormat = config["valueFormatter"].stringValue
-                customFormatter.negativeFormat = config["valueFormatter"].stringValue
+                customFormatter.positiveFormat = valueFormatter.stringValue
+                customFormatter.negativeFormat = valueFormatter.stringValue
                 
                 dataSet.valueFormatter = DefaultValueFormatter(formatter: customFormatter);
             }

--- a/lib/AxisIface.js
+++ b/lib/AxisIface.js
@@ -45,10 +45,11 @@ export const axisIface = {
 
   // formatting
   valueFormatter: PropTypes.oneOfType([
-    PropTypes.oneOf(['largeValue', 'percent']),
+    PropTypes.oneOf(['largeValue', 'percent', 'date']),
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string)
   ]),
+  valueFormatterPattern: PropTypes.string,
 };
 
 export const xAxisIface = {

--- a/lib/ChartDataSetConfig.js
+++ b/lib/ChartDataSetConfig.js
@@ -14,9 +14,10 @@ const chartDataSetConfig = {
     valueTextColor:PropTypes.number,
     visible:PropTypes.bool,
     valueFormatter: PropTypes.oneOfType([
-      PropTypes.oneOf(['largeValue', 'percent']),
+      PropTypes.oneOf(['largeValue', 'percent', 'date']),
       PropTypes.string
     ]),
+    valueFormatterPattern: PropTypes.string,
     axisDependency:PropTypes.string
   },
 


### PR DESCRIPTION
Added option `date` to prop `valueFormatter` and created prop `valueFormatterPattern` to set the pattern.

Example:

```js
xAxis = {
    $set: {
        valueFormatter: 'date',
        valueFormatterPattern: 'HH:mm',
        position: 'BOTTOM',
    }
}
```

Thus, it is possible to set the date/time on the X-axis in milliseconds since 1970.
```js
data: {
       $set: {
          dataSets: [{
               values: [{y: 226, x: 1504705978477}, {y: 230, x: 1504706000731}, .... ],
               ...
           }]
       }
}
```

Android:
![whatsapp image 2017-09-05 at 14 31 32](https://user-images.githubusercontent.com/1512341/30115367-e5826a2a-92f0-11e7-9c32-1c78e7bfc3bd.jpeg)

iOS:
![simulator screen shot 6 de set de 2017 09 16 22](https://user-images.githubusercontent.com/1512341/30115379-efd68006-92f0-11e7-96f6-97f20adbb20f.png)

