### PR TITLE
React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead.

### DIFF
--- a/ios/ReactNativeCharts/radar/RNRadarChartView.swift
+++ b/ios/ReactNativeCharts/radar/RNRadarChartView.swift
@@ -6,38 +6,46 @@ import Charts
 import SwiftyJSON
 
 class RNRadarChartView: RNYAxisChartViewBase {
-    
+
     let _chart: RadarChartView;
     let _dataExtract : RadarDataExtract
-    
+
+    override func setYAxis(_ config: NSDictionary) {
+        let json = BridgeUtils.toJson(config)
+
+        let yAxis = _chart.yAxis
+        setCommonAxisConfig(yAxis, config: json);
+        setYAxisConfig(yAxis, config: json);
+    }
+
     override var chart: RadarChartView {
         return _chart
     }
-    
+
     override var dataExtract: DataExtract {
         return _dataExtract
     }
-    
+
     override init(frame: CoreGraphics.CGRect) {
-        
+
         self._chart = RadarChartView(frame: frame)
         self._dataExtract = RadarDataExtract()
-        
+
         super.init(frame: frame)
-      
+
         self._chart.delegate = self
         self.addSubview(_chart)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
- 
+
+
     func setSkipWebLineCount(_ count: Int) {
         _chart.skipWebLineCount = count
     }
-    
+
     func setRotationEnabled(_ enabled: Bool) {
         _chart.rotationEnabled = enabled
     }

--- a/lib/AxisIface.js
+++ b/lib/AxisIface.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 
 export const axisIface = {
   // what is drawn

--- a/lib/BarChart.js
+++ b/lib/BarChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/BarLineChartBase.js
+++ b/lib/BarLineChartBase.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   View
 } from 'react-native';

--- a/lib/BubbleChart.js
+++ b/lib/BubbleChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/CandleStickChart.js
+++ b/lib/CandleStickChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/ChartBase.js
+++ b/lib/ChartBase.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   View
 } from 'react-native';

--- a/lib/ChartDataConfig.js
+++ b/lib/ChartDataConfig.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import ChartDataSetConfig from './ChartDataSetConfig';
 
 

--- a/lib/ChartDataSetConfig.js
+++ b/lib/ChartDataSetConfig.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/CombinedChart.js
+++ b/lib/CombinedChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/HorizontalBarChart.js
+++ b/lib/HorizontalBarChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/LineChart.js
+++ b/lib/LineChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/PieChart.js
+++ b/lib/PieChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/PieRadarChartBase.js
+++ b/lib/PieRadarChartBase.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   View
 } from 'react-native';

--- a/lib/RadarChart.js
+++ b/lib/RadarChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View

--- a/lib/ScatterChart.js
+++ b/lib/ScatterChart.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 import {
   requireNativeComponent,
   View


### PR DESCRIPTION
React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead. 

&& 

ovveride function setYAxis for RNRadarChartView
--


