### PR TITLE
NormalizeSizeEnabled for Bubble Charts

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/data/BubbleDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/BubbleDataExtract.java
@@ -40,6 +40,9 @@ public class BubbleDataExtract extends DataExtract<BubbleData, BubbleEntry> {
         if (BridgeUtils.validate(config, ReadableType.Number, "highlightCircleWidth")) {
             bubbleDataSet.setHighlightCircleWidth((float) config.getDouble("highlightCircleWidth"));
         }
+        if (BridgeUtils.validate(config, ReadableType.Boolean, "normalizeSizeEnabled")) {
+            bubbleDataSet.setNormalizeSizeEnabled(config.getBoolean("normalizeSizeEnabled"));
+        }
     }
 
     @Override

--- a/ios/ReactNativeCharts/bubble/BubbleDataExtract.swift
+++ b/ios/ReactNativeCharts/bubble/BubbleDataExtract.swift
@@ -26,6 +26,9 @@ class BubbleDataExtract : DataExtract {
         if config["highlightCircleWidth"].number != nil {
             bubbleDataSet.highlightCircleWidth = CGFloat(config["highlightCircleWidth"].numberValue)
         }
+        if config["normalizeSizeEnabled"].number != nil {
+            bubbleDataSet.normalizeSizeEnabled = config["normalizeSizeEnabled"].boolValue
+        }
     }
     
     override func createEntry(_ values: [JSON], index: Int) -> ChartDataEntry {

--- a/ios/ReactNativeCharts/bubble/BubbleDataExtract.swift
+++ b/ios/ReactNativeCharts/bubble/BubbleDataExtract.swift
@@ -26,7 +26,7 @@ class BubbleDataExtract : DataExtract {
         if config["highlightCircleWidth"].number != nil {
             bubbleDataSet.highlightCircleWidth = CGFloat(config["highlightCircleWidth"].numberValue)
         }
-        if config["normalizeSizeEnabled"].number != nil {
+        if config["normalizeSizeEnabled"].bool != nil {
             bubbleDataSet.normalizeSizeEnabled = config["normalizeSizeEnabled"].boolValue
         }
     }


### PR DESCRIPTION
Added normalizeSizeEnabled for bubble charts. Allows you to use the actual size for each bubble rather than having it scale based on largest value.

See https://github.com/PhilJay/MPAndroidChart/issues/2185 and https://github.com/danielgindi/Charts/issues/692