### PR TITLE
Fix visibleRange not working in iOS

### DIFF
--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -76,7 +76,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
             barLineChart.leftAxis.axisMinimum = y["left"]["min"].doubleValue
         }
         if y["left"]["max"].double != nil {
-            barLineChart.leftAxis.axisMaximum = y["left"]["min"].doubleValue
+            barLineChart.leftAxis.axisMaximum = y["left"]["max"].doubleValue
         }
         
         if y["right"]["min"].double != nil {

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -65,25 +65,25 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         
         let x = json["x"]
         if x["min"].double != nil {
-            barLineChart.setVisibleXRangeMinimum(x["min"].doubleValue)
+            barLineChart.xAxis.axisMinimum = x["min"].doubleValue
         }
         if x["max"].double != nil {
-            barLineChart.setVisibleXRangeMaximum(x["max"].doubleValue)
+            barLineChart.xAxis.axisMaximum = x["max"].doubleValue
         }
         
         let y = json["y"]
         if y["left"]["min"].double != nil {
-            barLineChart.setVisibleYRangeMinimum(y["left"]["min"].doubleValue, axis: YAxis.AxisDependency.left)
+            barLineChart.leftAxis.axisMinimum = y["left"]["min"].doubleValue
         }
         if y["left"]["max"].double != nil {
-            barLineChart.setVisibleYRangeMaximum(y["left"]["max"].doubleValue, axis: YAxis.AxisDependency.left)
+            barLineChart.leftAxis.axisMaximum = y["left"]["min"].doubleValue
         }
         
         if y["right"]["min"].double != nil {
-            barLineChart.setVisibleYRangeMinimum(y["right"]["min"].doubleValue, axis: YAxis.AxisDependency.right)
+            barLineChart.rightAxis.axisMinimum = y["right"]["min"].doubleValue
         }
         if y["right"]["max"].double != nil {
-            barLineChart.setVisibleYRangeMaximum(y["right"]["max"].doubleValue, axis: YAxis.AxisDependency.right)
+            barLineChart.rightAxis.axisMaximum = y["right"]["max"].doubleValue
         }
     }
     


### PR DESCRIPTION
Updated the file to use the new APIs provided by iOS Charts. It seems setVisibleXRange in iOS is not working and alternative APIs are provided by iOS Charts.

There's a bit of discussion around this in Stack Overflow - https://stackoverflow.com/questions/32176581/ios-charts-set-minimum-y-axis-range

Updating the code to use xAxis, leftAxis, rightAxis based on this answer. I've tested xAxis on an iPhone simulator and found to be working.

Tested against iOS Charts 3.0.3