### PR TITLE
Support extraOffsets

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -186,6 +186,25 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
         chart.setViewPortOffsets((float) left, (float) top, (float) right, (float) bottom);
     }
 
+    @ReactProp(name = "extraOffsets")
+    public void setExtraOffsets(BarLineChartBase chart, ReadableMap propMap) {
+        double left = 0, top = 0, right = 0, bottom = 0;
+
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "left")) {
+            left = propMap.getDouble("left");
+        }
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "top")) {
+            top = propMap.getDouble("top");
+        }
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "right")) {
+            right = propMap.getDouble("right");
+        }
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "bottom")) {
+            bottom = propMap.getDouble("bottom");
+        }
+        chart.setExtraOffsets((float) left, (float) top, (float) right, (float) bottom);
+    }
+
     @Nullable
     @Override
     public Map<String, Integer> getCommandsMap() {

--- a/ios/ReactNativeCharts/RNBarLineChartManagerBridge.h
+++ b/ios/ReactNativeCharts/RNBarLineChartManagerBridge.h
@@ -24,6 +24,7 @@ RCT_EXPORT_VIEW_PROPERTY(pinchZoom, BOOL) \
 RCT_EXPORT_VIEW_PROPERTY(doubleTapToZoomEnabled, BOOL) \
 RCT_EXPORT_VIEW_PROPERTY(zoom, NSDictionary) \
 RCT_EXPORT_VIEW_PROPERTY(viewPortOffsets, NSDictionary) \
+RCT_EXPORT_VIEW_PROPERTY(extraOffsets, NSDictionary) \
 RCT_EXTERN_METHOD(moveViewToX:(nonnull NSNumber *)node xValue:(nonnull NSNumber *)xValue) \
 RCT_EXTERN_METHOD(moveViewTo:(nonnull NSNumber *)node xValue:(nonnull NSNumber *)xValue yValue:(nonnull NSNumber *)yValue axisDependency:(nonnull NSString *)axisDependency) \
 RCT_EXTERN_METHOD(moveViewToAnimated:(nonnull NSNumber *)node xValue:(nonnull NSNumber *)xValue yValue:(nonnull NSNumber *)yValue axisDependency:(nonnull NSString *)axisDependency duration:(nonnull NSNumber *)duration) \

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -143,11 +143,21 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         let json = BridgeUtils.toJson(config)
 
         let left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
-        let top = json["top"].double != nil ? CGFloat(json["left"].doubleValue) : 0
+        let top = json["top"].double != nil ? CGFloat(json["top"].doubleValue) : 0
         let right = json["right"].double != nil ? CGFloat(json["right"].doubleValue) : 0
         let bottom = json["bottom"].double != nil ? CGFloat(json["bottom"].doubleValue) : 0
 
         barLineChart.setViewPortOffsets(left: left, top: top, right: right, bottom: bottom)
     }
 
+    func setExtraOffsets(_ config: NSDictionary) {
+        let json = BridgeUtils.toJson(config)
+    
+        let left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
+        let top = json["top"].double != nil ? CGFloat(json["top"].doubleValue) : 0
+        let right = json["right"].double != nil ? CGFloat(json["right"].doubleValue) : 0
+        let bottom = json["bottom"].double != nil ? CGFloat(json["bottom"].doubleValue) : 0
+    
+        barLineChart.setExtraOffsets(left: left, top: top, right: right, bottom: bottom)
+    }
 }

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -23,7 +23,7 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         super.reactSetFrame(frame);
         
         let chartFrame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
-        chart.reactSetFrame(chartFrame);
+        chart.reactSetFrame(chartFrame)
     }
     
     var chart: ChartViewBase {

--- a/lib/BarLineChartBase.js
+++ b/lib/BarLineChartBase.js
@@ -62,6 +62,12 @@ const iface = {
       right: PropTypes.number,
       bottom: PropTypes.number
     }),
+    extraOffsets: PropTypes.shape({
+      left: PropTypes.number,
+      top: PropTypes.number, 
+      right: PropTypes.number,
+      bottom: PropTypes.number
+    }),
   }
 };
 


### PR DESCRIPTION
React Native Charts Wrapper now supports the extraOffsets feature for
BarChart, HorizontalBarChart, and LineChart, on iOS and Android.

The extraOffsets property allows developers to overcome clipping issues
such as http://github.com/PhilJay/MPAndroidChart/issues/1657 or
http://stackoverflow.com/q/32169593/2619107.

Bug fix in the setViewPortOffsets method of "RNBarLineChartViewBase. It
was using the left JSON property for the top parameter of the underlying
barLineChart.setViewPortOffsets call.