### PR TITLE
Fixes react-native-maps collisions

### DIFF
--- a/ios/ReactNativeCharts/RNChartManagerBridge.h
+++ b/ios/ReactNativeCharts/RNChartManagerBridge.h
@@ -22,7 +22,7 @@ RCT_EXPORT_VIEW_PROPERTY(dragDecelerationFrictionCoef, NSNumber) \
 RCT_EXPORT_VIEW_PROPERTY(animation, NSDictionary) \
 RCT_EXPORT_VIEW_PROPERTY(xAxis, NSDictionary) \
 RCT_EXPORT_VIEW_PROPERTY(marker, NSDictionary) \
-RCT_EXPORT_VIEW_PROPERTY(onSelect, RCTBubblingEventBlock) \
+RCT_EXPORT_VIEW_PROPERTY(onChartSelect, RCTBubblingEventBlock) \
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 
 

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -14,7 +14,7 @@ import SwiftyJSON
 
 @objcMembers
 open class RNChartViewBase: UIView, ChartViewDelegate {
-    open var onSelect:RCTBubblingEventBlock?
+    open var onChartSelect:RCTBubblingEventBlock?
     
     open var onChange:RCTBubblingEventBlock?
     
@@ -470,19 +470,19 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
     
     @objc public func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight) {
         
-        if self.onSelect == nil {
+        if self.onChartSelect == nil {
             return
         } else {
-            self.onSelect!(EntryToDictionaryUtils.entryToDictionary(entry))
+            self.onChartSelect!(EntryToDictionaryUtils.entryToDictionary(entry))
             
         }
     }
     
     @objc public func chartValueNothingSelected(_ chartView: ChartViewBase) {
-        if self.onSelect == nil {
+        if self.onChartSelect == nil {
             return
         } else {
-            self.onSelect!(nil)
+            self.onChartSelect!(nil)
             
         }
     }

--- a/lib/BarChart.js
+++ b/lib/BarChart.js
@@ -34,7 +34,7 @@ BarChart.propTypes = {
 }
 
 var RNBarChart = requireNativeComponent('RNBarChart', BarChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 })
 
 export default ScaleEnhancer(MoveEnhancer(BarChart))

--- a/lib/BubbleChart.js
+++ b/lib/BubbleChart.js
@@ -31,7 +31,7 @@ BubbleChart.propTypes = {
 };
 
 var RNBubbleChart = requireNativeComponent('RNBubbleChart', BubbleChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 });
 
 export default ScaleEnhancer(MoveEnhancer(BubbleChart))

--- a/lib/CandleStickChart.js
+++ b/lib/CandleStickChart.js
@@ -32,7 +32,7 @@ CandleStickChart.propTypes = {
 };
 
 var RNCandleStickChart = requireNativeComponent('RNCandleStickChart', CandleStickChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 });
 
 export default ScaleEnhancer(MoveEnhancer(CandleStickChart))

--- a/lib/CombinedChart.js
+++ b/lib/CombinedChart.js
@@ -32,7 +32,7 @@ CombinedChart.propTypes = {
 };
 
 var RNCombinedChart = requireNativeComponent('RNCombinedChart', CombinedChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 });
 
 export default ScaleEnhancer(MoveEnhancer(CombinedChart))

--- a/lib/HorizontalBarChart.js
+++ b/lib/HorizontalBarChart.js
@@ -35,7 +35,7 @@ HorizontalBarChart.propTypes = {
 };
 
 var RNHorizontalBarChart = requireNativeComponent('RNHorizontalBarChart', HorizontalBarChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 });
 
 export default ScaleEnhancer(MoveEnhancer(HorizontalBarChart))

--- a/lib/LineChart.js
+++ b/lib/LineChart.js
@@ -31,7 +31,7 @@ LineChart.propTypes = {
 };
 
 var RNLineChart = requireNativeComponent('RNLineChart', LineChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 });
 
 export default ScaleEnhancer(MoveEnhancer(LineChart))

--- a/lib/PieChart.js
+++ b/lib/PieChart.js
@@ -49,7 +49,7 @@ PieChart.propTypes = {
 };
 
 var RNPieChart = requireNativeComponent('RNPieChart', PieChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 });
 
 export default PieChart

--- a/lib/RadarChart.js
+++ b/lib/RadarChart.js
@@ -35,7 +35,7 @@ RadarChart.propTypes = {
 };
 
 var RNRadarChart = requireNativeComponent('RNRadarChart', RadarChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 });
 
 export default RadarChart

--- a/lib/ScatterChart.js
+++ b/lib/ScatterChart.js
@@ -30,7 +30,7 @@ ScatterChart.propTypes = {
 };
 
 var RNScatterChart = requireNativeComponent('RNScatterChart', ScatterChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onChartSelect: true, onChange: true}
 });
 
 export default ScaleEnhancer(MoveEnhancer(ScatterChart))


### PR DESCRIPTION
onSelect event is colliding with react-native-maps, to prevent the collision onSelect has be changed to onChartSelect.