### PR TITLE
docs: Missing imports

### DIFF
--- a/installation_guide/README.md
+++ b/installation_guide/README.md
@@ -185,6 +185,9 @@ distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
 Add following code to MainApplication.java for RN >= 0.54, check [#229](https://github.com/wuxudong/react-native-charts-wrapper/issues/229) and the code in android example.
 
 ```java
+  import com.facebook.react.bridge.ReadableNativeArray;
+  import com.facebook.react.bridge.ReadableNativeMap;
+  
   @Override
   public void onCreate() {
     super.onCreate();


### PR DESCRIPTION
## Motivation
I'm not a Java developer, so wasn't clear that i have to import the bridges from facebook namespace. 

Leaving the imports in the documentation could be helpful for future new users.

## Changes
- Add the imports above of the comment about the changes in the `MainApplication.java` file.

![image](https://user-images.githubusercontent.com/1863024/46340338-739c7580-c635-11e8-885c-44a16f79fa77.png)
