### PR TITLE
Changes to support compiling with Swift 5

### DIFF
--- a/ios/ReactNativeCharts/ChartGroupHolder.swift
+++ b/ios/ReactNativeCharts/ChartGroupHolder.swift
@@ -24,7 +24,7 @@ class ChartHolder {
 open class ChartGroupHolder {
     static var chartGroup: Dictionary<String, Dictionary<String, ChartHolder>> = [:]
     
-    open static func addChart(group: String, identifier: String ,  chart: BarLineChartViewBase,  syncX: Bool, syncY: Bool) {
+    public static func addChart(group: String, identifier: String ,  chart: BarLineChartViewBase,  syncX: Bool, syncY: Bool) {
         objc_sync_enter(chartGroup)
         defer { objc_sync_exit(chartGroup) }
         
@@ -39,7 +39,7 @@ open class ChartGroupHolder {
     
     
     // sync gesture to other chart in the same group
-    open static func sync( group: String,  identifier: String,  scaleX: CGFloat,  scaleY:CGFloat,  centerX: CGFloat,  centerY:CGFloat,  performImmediately: Bool) {
+    public static func sync( group: String,  identifier: String,  scaleX: CGFloat,  scaleY:CGFloat,  centerX: CGFloat,  centerY:CGFloat,  performImmediately: Bool) {
         
         objc_sync_enter(chartGroup)
         defer { objc_sync_exit(chartGroup) }

--- a/ios/ReactNativeCharts/bar/RNBarChartManager.swift
+++ b/ios/ReactNativeCharts/bar/RNBarChartManager.swift
@@ -14,7 +14,7 @@ open class RNBarChartManager: RCTViewManager, RNBarLineChartBaseManager {
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
   

--- a/ios/ReactNativeCharts/bar/RNHorizontalBarChartManager.swift
+++ b/ios/ReactNativeCharts/bar/RNHorizontalBarChartManager.swift
@@ -14,7 +14,7 @@ open class RNHorizontalBarChartManager: RCTViewManager, RNBarLineChartBaseManage
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
   

--- a/ios/ReactNativeCharts/bubble/RNBubbleChartManager.swift
+++ b/ios/ReactNativeCharts/bubble/RNBubbleChartManager.swift
@@ -14,7 +14,7 @@ open class RNBubbleChartManager: RCTViewManager, RNBarLineChartBaseManager {
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
 

--- a/ios/ReactNativeCharts/candlestick/RNCandleStickChartManager.swift
+++ b/ios/ReactNativeCharts/candlestick/RNCandleStickChartManager.swift
@@ -14,7 +14,7 @@ open class RNCandleStickChartManager: RCTViewManager, RNBarLineChartBaseManager 
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
   

--- a/ios/ReactNativeCharts/combine/RNCombinedChartManager.swift
+++ b/ios/ReactNativeCharts/combine/RNCombinedChartManager.swift
@@ -14,7 +14,7 @@ open class RNCombinedChartManager: RCTViewManager, RNBarLineChartBaseManager {
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
   

--- a/ios/ReactNativeCharts/line/RNLineChartManager.swift
+++ b/ios/ReactNativeCharts/line/RNLineChartManager.swift
@@ -14,7 +14,7 @@ open class RNLineChartManager: RCTViewManager, RNBarLineChartBaseManager {
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
   

--- a/ios/ReactNativeCharts/pie/RNPieChartManager.swift
+++ b/ios/ReactNativeCharts/pie/RNPieChartManager.swift
@@ -12,7 +12,7 @@ open class RNPieChartManager: RCTViewManager {
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
 

--- a/ios/ReactNativeCharts/radar/RNRadarChartManager.swift
+++ b/ios/ReactNativeCharts/radar/RNRadarChartManager.swift
@@ -12,7 +12,7 @@ open class RNRadarChartManager: RCTViewManager {
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
 

--- a/ios/ReactNativeCharts/scatter/RNScatterChartManager.swift
+++ b/ios/ReactNativeCharts/scatter/RNScatterChartManager.swift
@@ -14,7 +14,7 @@ class RNScatterChartManager: RCTViewManager, RNBarLineChartBaseManager {
     return ins;
   }
 
-  override open static func requiresMainQueueSetup() -> Bool {
+  override public static func requiresMainQueueSetup() -> Bool {
     return true;
   }
   


### PR DESCRIPTION
Hello! Thank you very much for your library.  My iOS project has been upgraded to Swift 5 and when including the files in my project I get a number of compilation errors like this:

`Static declarations are implicitly 'final'; use 'public' instead of 'open'`

![Pasted Graphic](https://user-images.githubusercontent.com/11227540/56097171-cb6f3f80-5ee8-11e9-8104-f500a9da4a58.png)

I believe the change is fully backward compatible to all previous Swift versions, so it shouldn't present any issues.