### PR TITLE
[iOS]: Large value works incorrecty for small ranges and negative numbers

### DIFF
--- a/ios/ReactNativeCharts/formatters/LargeValueFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/LargeValueFormatter.swift
@@ -31,7 +31,7 @@ open class LargeValueFormatter: NSObject, IValueFormatter, IAxisValueFormatter
     fileprivate func format(_ value: Double) -> String
     {
         var sig = abs(value)
-        let sign = value < 0 ? "-" : "+"
+        let sign = value < 0 ? "-" : ""
         var length = 0
         let maxLength = suffix.count - 1
 

--- a/ios/ReactNativeCharts/formatters/LargeValueFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/LargeValueFormatter.swift
@@ -9,53 +9,58 @@ import Charts
 open class LargeValueFormatter: NSObject, IValueFormatter, IAxisValueFormatter
 {
     fileprivate static let MAX_LENGTH = 5
-    
+
     /// Suffix to be appended after the values.
     ///
     /// **default**: suffix: ["", "k", "m", "b", "t"]
     open var suffix = ["", "k", "m", "b", "t"]
-    
+
     /// An appendix text to be added at the end of the formatted value.
     open var appendix: String?
-    
+
     public override init()
     {
-        
+
     }
-    
+
     public init(appendix: String?)
     {
         self.appendix = appendix
     }
-    
+
     fileprivate func format(_ value: Double) -> String
     {
-        var sig = value
+        var sig = abs(value)
+        let sign = value < 0 ? "-" : "+"
         var length = 0
         let maxLength = suffix.count - 1
-        
+
         while sig >= 1000.0 && length < maxLength
         {
             sig /= 1000.0
             length += 1
         }
-        
-        var r = String(format: "%2.f", sig) + suffix[length]
-        
+
+        let valueFormatter = NumberFormatter()
+        valueFormatter.maximumFractionDigits = 2
+        valueFormatter.minimumFractionDigits = 0
+
+        var r = sign + (valueFormatter.string(from: NSNumber(value: sig)) ?? "") + suffix[length]
+
         if appendix != nil
         {
             r += appendix!
         }
-        
+
         return r
     }
-    
+
     open func stringForValue(
         _ value: Double, axis: AxisBase?) -> String
     {
         return format(value)
     }
-    
+
     open func stringForValue(
         _ value: Double,
         entry: ChartDataEntry,


### PR DESCRIPTION
Hey!
Got 2 problems
1. Negative numbers aren't converted by largeValueFormatter
![image](https://user-images.githubusercontent.com/12534630/56419091-c2dc8780-62a1-11e9-9c47-cf348187b415.png)
2. When there's a small difference in large numbers largeValueFormatter too roughly rounds them
![image](https://user-images.githubusercontent.com/12534630/56419158-fb7c6100-62a1-11e9-97d6-1dfa76d51955.png)
