### PR TITLE
Add locale property for valueFormatter

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -444,7 +444,13 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
                 if (BridgeUtils.validate(propMap, ReadableType.String, "timeUnit")) {
                     timeUnit = TimeUnit.valueOf(propMap.getString("timeUnit").toUpperCase());
                 }
-                axis.setValueFormatter(new DateFormatter(valueFormatterPattern, since, timeUnit));
+                Locale locale = Locale.getDefault();
+                
+                if (BridgeUtils.validate(propMap, ReadableType.String, "locale")) {
+                    locale = Locale.forLanguageTag(propMap.getString("locale"));
+                }
+
+                axis.setValueFormatter(new DateFormatter(valueFormatterPattern, since, timeUnit, locale));
             } else {
                 axis.setValueFormatter(new CustomFormatter(valueFormatter));
             }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/DateFormatter.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/DateFormatter.java
@@ -6,6 +6,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import java.util.Locale;
 
 /**
  * Created by dougl on 05/09/2017.
@@ -18,8 +19,8 @@ public class DateFormatter extends ValueFormatter {
 
     private TimeUnit timeUnit;
 
-    public DateFormatter(String pattern, long since, TimeUnit timeUnit) {
-        mFormat = new SimpleDateFormat(pattern);
+    public DateFormatter(String pattern, long since, TimeUnit timeUnit, Locale locale) {
+        mFormat = new SimpleDateFormat(pattern, locale);
 
         this.since = since;
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
@@ -79,7 +79,14 @@ public class ChartDataSetConfigUtils {
                 if (BridgeUtils.validate(config, ReadableType.String, "timeUnit")) {
                     timeUnit = TimeUnit.valueOf(config.getString("timeUnit").toUpperCase());
                 }
-                dataSet.setValueFormatter(new DateFormatter(valueFormatterPattern, since, timeUnit));
+
+                Locale locale = Locale.getDefault();
+                
+                if (BridgeUtils.validate(config, ReadableType.String, "locale")) {
+                    locale = Locale.forLanguageTag(config.getString("locale"));
+                }
+
+                dataSet.setValueFormatter(new DateFormatter(valueFormatterPattern, since, timeUnit, locale));
             } else {
                 dataSet.setValueFormatter(new CustomFormatter(valueFormatter));
             }

--- a/ios/ReactNativeCharts/CustomChartDateFormatter.swift
+++ b/ios/ReactNativeCharts/CustomChartDateFormatter.swift
@@ -20,7 +20,8 @@ open class CustomChartDateFormatter: NSObject, IValueFormatter, IAxisValueFormat
         
     }
     
-    public init(pattern: String?, since: Double, timeUnit: String?) {
+    public init(pattern: String?, since: Double, timeUnit: String?, locale: String?) {
+        self.dateFormatter.locale = Locale(identifier: locale ?? Locale.current.languageCode ?? "en_US");
         self.dateFormatter.dateFormat = pattern;
         self.since = since
         self.timeUnit = timeUnit

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -412,7 +412,8 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
               let valueFormatterPattern = config["valueFormatterPattern"].stringValue;
               let since = config["since"].double != nil ? config["since"].doubleValue : 0
               let timeUnit = config["timeUnit"].string != nil ? config["timeUnit"].stringValue : "MILLISECONDS"
-              axis.valueFormatter = CustomChartDateFormatter(pattern: valueFormatterPattern, since: since, timeUnit: timeUnit);
+              let locale = config["locale"].string;
+              axis.valueFormatter = CustomChartDateFormatter(pattern: valueFormatterPattern, since: since, timeUnit: timeUnit, locale: locale);
             } else {
               let customFormatter = NumberFormatter()
               customFormatter.positiveFormat = valueFormatter.stringValue

--- a/ios/ReactNativeCharts/utils/ChartDataSetConfigUtils.swift
+++ b/ios/ReactNativeCharts/utils/ChartDataSetConfigUtils.swift
@@ -55,7 +55,8 @@ class ChartDataSetConfigUtils: NSObject {
                 let valueFormatterPattern = config["valueFormatterPattern"].stringValue;
                 let since = config["since"].double != nil ? config["since"].doubleValue : 0
                 let timeUnit = config["timeUnit"].string != nil ? config["timeUnit"].stringValue : "MILLISECONDS"
-                dataSet.valueFormatter = CustomChartDateFormatter(pattern: valueFormatterPattern, since: since, timeUnit: timeUnit);
+                let locale = config["locale"].string;
+                dataSet.valueFormatter = CustomChartDateFormatter(pattern: valueFormatterPattern, since: since, timeUnit: timeUnit, locale: locale);
             } else {
                 let customFormatter = NumberFormatter()
                 customFormatter.positiveFormat = valueFormatter.stringValue


### PR DESCRIPTION
Adds the possibility to choose the formatting locale from JS. Also fixes the lack of locale control in iOS. When omitted, it will use the system locale instead. 