### PR TITLE
Render images instead of circles for data points in LineChart

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
@@ -102,12 +102,7 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
                 ReadableMap bundle = icon.getMap("bundle");
                 int width = icon.getInt("width");
                 int height = icon.getInt("height");
-                try {
-                    entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height));
-                } catch (Exception e){
-                    e.printStackTrace();
-                    throw new IllegalArgumentException("Unexpected url: " + bundle.getString("uri"));
-                }
+                entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height));
 
             } else {
                 entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
@@ -11,20 +11,10 @@ import com.github.mikephil.charting.interfaces.datasets.IDataSet;
 import com.github.wuxudong.rncharts.utils.BridgeUtils;
 import com.github.wuxudong.rncharts.utils.ChartDataSetConfigUtils;
 import com.github.wuxudong.rncharts.utils.ConversionUtil;
+import com.github.wuxudong.rncharts.utils.DrawableUtils;
 
 import java.lang.Exception;
 import java.util.ArrayList;
-import android.util.Log;
-import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.Drawable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import android.os.AsyncTask;
 
 
 /**
@@ -113,7 +103,7 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
                 int width = icon.getInt("width");
                 int height = icon.getInt("height");
                 try {
-                    entry = new Entry(x, (float) map.getDouble("y"), drawableFromUrl(bundle.getString("uri"), width, height));
+                    entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height));
                 } catch (Exception e){
                     e.printStackTrace();
                     throw new IllegalArgumentException("Unexpected url: " + bundle.getString("uri"));
@@ -131,35 +121,5 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
         return entry;
     }
 
-    public Drawable drawableFromUrl(String url, final int width, final int height) throws IOException {
 
-        AsyncTask<String, Void, Drawable> asyncTask = new AsyncTask<String, Void, Drawable>() {
-            @Override
-            protected Drawable doInBackground(String... strings) {
-                try {
-                    Bitmap x;
-
-                    HttpURLConnection connection = (HttpURLConnection) new URL(strings[0]).openConnection();
-                    connection.connect();
-                    InputStream input = connection.getInputStream();
-
-                    x = BitmapFactory.decodeStream(input);
-
-                    return new BitmapDrawable(Resources.getSystem(), Bitmap.createScaledBitmap(x, width, height, true));
-
-                } catch(IOException e) {
-                    e.printStackTrace();
-                    return null;
-                }
-            }
-        };
-
-        try {
-            Drawable response = asyncTask.execute(url).get();
-            return response;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/utils/DrawableUtils.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/utils/DrawableUtils.java
@@ -1,0 +1,49 @@
+package com.github.wuxudong.rncharts.utils;
+
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.AsyncTask;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class DrawableUtils {
+    public static Drawable drawableFromUrl(String url, final int width, final int height) {
+        try {
+            Drawable response = new DrawableLoadingAsyncTask().execute(url, Integer.toString(width), Integer.toString(height)).get();
+            return response;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    static class DrawableLoadingAsyncTask extends AsyncTask<String, Void, Drawable> {
+        @Override
+        protected Drawable doInBackground(String... strings) {
+            try {
+                Bitmap x;
+
+                int width = Integer.parseInt(strings[1]);
+                int height = Integer.parseInt(strings[2]);
+
+                HttpURLConnection connection = (HttpURLConnection) new URL(strings[0]).openConnection();
+                connection.connect();
+                InputStream input = connection.getInputStream();
+
+                x = BitmapFactory.decodeStream(input);
+
+                return new BitmapDrawable(Resources.getSystem(), Bitmap.createScaledBitmap(x, width, height, true));
+
+            } catch(IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+    };
+}

--- a/android/src/main/java/com/github/wuxudong/rncharts/utils/DrawableUtils.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/utils/DrawableUtils.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.ShapeDrawable;
 import android.os.AsyncTask;
 
 import java.io.IOException;
@@ -15,11 +16,11 @@ import java.net.URL;
 public class DrawableUtils {
     public static Drawable drawableFromUrl(String url, final int width, final int height) {
         try {
-            Drawable response = new DrawableLoadingAsyncTask().execute(url, Integer.toString(width), Integer.toString(height)).get();
-            return response;
+            return new DrawableLoadingAsyncTask().execute(url, Integer.toString(width), Integer.toString(height)).get();
         } catch (Exception e) {
+            // draw dummy drawable when execution fail
             e.printStackTrace();
-            return null;
+            return new ShapeDrawable();
         }
     }
 
@@ -42,7 +43,8 @@ public class DrawableUtils {
 
             } catch(IOException e) {
                 e.printStackTrace();
-                return null;
+                // draw dummy drawable when connection fail
+                return new ShapeDrawable();
             }
         }
     };

--- a/ios/ReactNativeCharts/RNCharts-Bridging-Header.h
+++ b/ios/ReactNativeCharts/RNCharts-Bridging-Header.h
@@ -6,3 +6,4 @@
 #import "React/RCTEventDispatcher.h"
 #import "React/RCTEventEmitter.h"
 #import "React/RCTFont.h"
+#import "React/RCTConvert.h"

--- a/ios/ReactNativeCharts/line/LineDataExtract.swift
+++ b/ios/ReactNativeCharts/line/LineDataExtract.swift
@@ -112,8 +112,8 @@ class LineDataExtract : DataExtract {
                     let bundle = icon["bundle"];
                     
                     let uiImage = RCTConvert.uiImage(bundle.dictionaryObject);
-                    let width = CGFloat(icon["width"].numberValue);
-                    let height = CGFloat(icon["height"].numberValue);
+                    let width = CGFloat(icon["width"].numberValue)/4;
+                    let height = CGFloat(icon["height"].numberValue)/4;
                     
                     if let image = uiImage {
                         let realIconImage = resizeImage(image: image, width: width, height: height);

--- a/ios/ReactNativeCharts/line/LineDataExtract.swift
+++ b/ios/ReactNativeCharts/line/LineDataExtract.swift
@@ -6,6 +6,7 @@ import Foundation
 
 import SwiftyJSON
 import Charts
+import UIKit
 
 class LineDataExtract : DataExtract {
     override func createData() -> ChartData {
@@ -111,7 +112,17 @@ class LineDataExtract : DataExtract {
                     let bundle = icon["bundle"];
                     
                     let uiImage = RCTConvert.uiImage(bundle.dictionaryObject);
-                    entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, icon: uiImage);
+                    let width = CGFloat(icon["width"].numberValue);
+                    let height = CGFloat(icon["height"].numberValue);
+                    
+                    if let image = uiImage {
+                        let realIconImage = resizeImage(image: image, width: width, height: height);
+                        entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, icon: realIconImage);
+                    } else {
+                        entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, icon: uiImage);
+                    } 
+                    
+                    
                 } else {
                     entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, data: dict as AnyObject?);
                 }
@@ -126,5 +137,32 @@ class LineDataExtract : DataExtract {
         }
         
         return entry;
+    }
+
+    func resizeImage(image: UIImage, width: CGFloat, height: CGFloat) -> UIImage {
+      let targetSize = CGSize(width: width, height: height)
+      let size = image.size
+
+      let widthRatio  = targetSize.width  / size.width
+      let heightRatio = targetSize.height / size.height
+
+      // Figure out what our orientation is, and use that to form the rectangle
+      var newSize: CGSize
+      if(widthRatio > heightRatio) {
+          newSize = CGSize(width: size.width * heightRatio, height: size.height * heightRatio)
+      } else {
+          newSize = CGSize(width: size.width * widthRatio,  height: size.height * widthRatio)
+      }
+
+      // This is the rect that we've calculated out and this is what is actually used below
+      let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
+
+      // Actually do the resizing to the rect using the ImageContext stuff
+      UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+      image.draw(in: rect)
+      let newImage = UIGraphicsGetImageFromCurrentImageContext()
+      UIGraphicsEndImageContext()
+
+      return newImage!
     }
 }

--- a/ios/ReactNativeCharts/line/LineDataExtract.swift
+++ b/ios/ReactNativeCharts/line/LineDataExtract.swift
@@ -93,17 +93,31 @@ class LineDataExtract : DataExtract {
         
         if value.dictionary != nil {
             let dict = value;
+            var y = Double(index);
             
             if dict["x"].double != nil {
                 x = Double((dict["x"].doubleValue));
             }
-            
+
             if dict["y"].number != nil {
-                entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, data: dict as AnyObject?);
+                y = dict["y"].doubleValue;
             } else {
                 fatalError("invalid data " + values.description);
             }
             
+            if dict["icon"].exists() {
+                let icon = dict["icon"]
+                if icon["bundle"].dictionary != nil {
+                    let bundle = icon["bundle"];
+                    
+                    let uiImage = RCTConvert.uiImage(bundle.dictionaryObject);
+                    entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, icon: uiImage);
+                } else {
+                    entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, data: dict as AnyObject?);
+                }
+            } else {
+                entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, data: dict as AnyObject?);
+            }
             
         } else if value.double != nil {
             entry = ChartDataEntry(x: x, y: value.doubleValue);

--- a/lib/ChartDataConfig.js
+++ b/lib/ChartDataConfig.js
@@ -1,72 +1,88 @@
-import PropTypes from 'prop-types';
-import ChartDataSetConfig from './ChartDataSetConfig';
-
+import PropTypes from "prop-types";
+import ChartDataSetConfig from "./ChartDataSetConfig";
 
 const lineData = PropTypes.shape({
-  dataSets: PropTypes.arrayOf(PropTypes.shape({
-    values: PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.shape({
-          x: PropTypes.number,
-          y: PropTypes.number.isRequired,
-          marker: PropTypes.string
-        }),
-        PropTypes.number
-      ])
-    ),
-    label: PropTypes.string.isRequired,
-    config: PropTypes.shape({
-      ...ChartDataSetConfig.common,
-      ...ChartDataSetConfig.barLineScatterCandleBubble,
-      ...ChartDataSetConfig.lineScatterCandleRadar,
-      ...ChartDataSetConfig.lineRadar,
+  dataSets: PropTypes.arrayOf(
+    PropTypes.shape({
+      values: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.shape({
+            x: PropTypes.number,
+            y: PropTypes.number.isRequired,
+            marker: PropTypes.string,
+            icon: PropTypes.shape({
+              bundle: PropTypes.object,
+              width: PropTypes.number,
+              height: PropTypes.number
+            })
+          }),
+          PropTypes.number
+        ])
+      ),
+      label: PropTypes.string.isRequired,
+      config: PropTypes.shape({
+        ...ChartDataSetConfig.common,
+        ...ChartDataSetConfig.barLineScatterCandleBubble,
+        ...ChartDataSetConfig.lineScatterCandleRadar,
+        ...ChartDataSetConfig.lineRadar,
 
-      circleRadius: PropTypes.number,
-      drawCircles: PropTypes.bool,
-      mode: PropTypes.oneOf(['LINEAR', 'STEPPED', 'CUBIC_BEZIER', 'HORIZONTAL_BEZIER']),
-      drawCubicIntensity: PropTypes.number,
-      circleColor: PropTypes.number,
-      circleColors: PropTypes.arrayOf(PropTypes.number),
-      circleHoleColor: PropTypes.number,
-      drawCircleHole: PropTypes.bool,
+        circleRadius: PropTypes.number,
+        drawCircles: PropTypes.bool,
+        mode: PropTypes.oneOf([
+          "LINEAR",
+          "STEPPED",
+          "CUBIC_BEZIER",
+          "HORIZONTAL_BEZIER"
+        ]),
+        drawCubicIntensity: PropTypes.number,
+        circleColor: PropTypes.number,
+        circleColors: PropTypes.arrayOf(PropTypes.number),
+        circleHoleColor: PropTypes.number,
+        drawCircleHole: PropTypes.bool,
 
-      dashedLine: PropTypes.shape({
-        lineLength: PropTypes.number.isRequired,
-        spaceLength: PropTypes.number.isRequired,
-        phase: PropTypes.number,
+        dashedLine: PropTypes.shape({
+          lineLength: PropTypes.number.isRequired,
+          spaceLength: PropTypes.number.isRequired,
+          phase: PropTypes.number
+        })
       })
     })
-  }))
-})
+  )
+});
 
 const barData = PropTypes.shape({
-  dataSets: PropTypes.arrayOf(PropTypes.shape({
-    values: PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.shape({
-          x: PropTypes.number,
-          y: PropTypes.oneOfType([
+  dataSets: PropTypes.arrayOf(
+    PropTypes.shape({
+      values: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.shape({
+            x: PropTypes.number,
+            y: PropTypes.oneOfType([
+              PropTypes.number,
+              PropTypes.arrayOf(PropTypes.number)
+            ]),
+            marker: PropTypes.oneOfType([
+              PropTypes.string,
+              PropTypes.arrayOf(PropTypes.string)
+            ])
+          }),
+          PropTypes.oneOfType([
             PropTypes.number,
             PropTypes.arrayOf(PropTypes.number)
-          ]),
-          marker: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)])
-        }),
-        PropTypes.oneOfType([
-          PropTypes.number,
-          PropTypes.arrayOf(PropTypes.number)
+          ])
         ])
-      ])
-    ),
-    label: PropTypes.string.isRequired,
-    config: PropTypes.shape({
-      ...ChartDataSetConfig.common,
-      ...ChartDataSetConfig.barLineScatterCandleBubble,
+      ),
+      label: PropTypes.string.isRequired,
+      config: PropTypes.shape({
+        ...ChartDataSetConfig.common,
+        ...ChartDataSetConfig.barLineScatterCandleBubble,
 
-      barShadowColor: PropTypes.number,
-      highlightAlpha: PropTypes.number,  // using android format (0-255), not ios format(0-1), the conversion is x/255
-      stackLabels: PropTypes.arrayOf(PropTypes.string)
+        barShadowColor: PropTypes.number,
+        highlightAlpha: PropTypes.number, // using android format (0-255), not ios format(0-1), the conversion is x/255
+        stackLabels: PropTypes.arrayOf(PropTypes.string)
+      })
     })
-  })),
+  ),
 
   config: PropTypes.shape({
     barWidth: PropTypes.number,
@@ -76,130 +92,153 @@ const barData = PropTypes.shape({
       barSpace: PropTypes.number.isRequired
     })
   })
-
-})
+});
 
 const bubbleData = PropTypes.shape({
-  dataSets: PropTypes.arrayOf(PropTypes.shape({
-    values: PropTypes.arrayOf(PropTypes.shape({
-      x: PropTypes.number,
-      y: PropTypes.number.isRequired,
-      size: PropTypes.number.isRequired,
-      marker: PropTypes.string,
-    })),
-    label: PropTypes.string.isRequired,
-    config: PropTypes.shape({
-      ...ChartDataSetConfig.common,
-      ...ChartDataSetConfig.barLineScatterCandleBubble,
-
-    })
-  }))
-})
-
-const candleData = PropTypes.shape({
-  dataSets: PropTypes.arrayOf(PropTypes.shape({
-    values: PropTypes.arrayOf(
-      PropTypes.shape({
-        x: PropTypes.number,
-        shadowH: PropTypes.number.isRequired,
-        shadowL: PropTypes.number.isRequired,
-        open: PropTypes.number.isRequired,
-        close: PropTypes.number.isRequired,
-        marker: PropTypes.string,
-      })
-    ),
-    label: PropTypes.string.isRequired,
-    config: PropTypes.shape({
-      ...ChartDataSetConfig.common,
-      ...ChartDataSetConfig.barLineScatterCandleBubble,
-      ...ChartDataSetConfig.lineScatterCandleRadar,
-
-      barSpace: PropTypes.number,
-      shadowWidth: PropTypes.number,
-      shadowColor: PropTypes.number,
-      shadowColorSameAsCandle: PropTypes.bool,
-      neutralColor: PropTypes.number,
-      decreasingColor: PropTypes.number,
-      decreasingPaintStyle: PropTypes.oneOf(['FILL', 'STROKE', 'FILL_AND_STROKE']),
-      increasingColor: PropTypes.number,
-      increasingPaintStyle: PropTypes.oneOf(['FILL', 'STROKE', 'FILL_AND_STROKE'])
-    })
-  })),
-})
-
-const pieData = PropTypes.shape({
-  dataSets: PropTypes.arrayOf(PropTypes.shape({
-    values: PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.shape({
-          value: PropTypes.number.isRequired,
-          label: PropTypes.string
-        }),
-        PropTypes.number
-      ])
-    ),
-    label: PropTypes.string.isRequired,
-    config: PropTypes.shape({
-      ...ChartDataSetConfig.common,
-
-      sliceSpace: PropTypes.number,
-      selectionShift: PropTypes.number,
-      xValuePosition: PropTypes.oneOf(['INSIDE_SLICE', 'OUTSIDE_SLICE']),
-      yValuePosition: PropTypes.oneOf(['INSIDE_SLICE', 'OUTSIDE_SLICE']),
-      valueLinePart1Length: PropTypes.number,
-      valueLinePart2Length: PropTypes.number,
-      valueLineColor: PropTypes.number,
-      valueLineWidth: PropTypes.number,
-      valueLinePart1OffsetPercentage: PropTypes.number,
-      valueLineVariableLength: PropTypes.bool
-    })
-  })),
-})
-
-const radarData = PropTypes.shape({
-  dataSets: PropTypes.arrayOf(PropTypes.shape({
-    values: PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.shape({value: PropTypes.number.isRequired,}),
-        PropTypes.number
-      ])
-    ),
-    label: PropTypes.string.isRequired,
-    config: PropTypes.shape({
-      ...ChartDataSetConfig.common,
-      ...ChartDataSetConfig.lineScatterCandleRadar,
-      ...ChartDataSetConfig.lineRadar
-
-    })
-  })),
-  labels: PropTypes.arrayOf(PropTypes.string)
-})
-
-const scatterData = PropTypes.shape({
-  dataSets: PropTypes.arrayOf(PropTypes.shape({
-    values: PropTypes.arrayOf(
-      PropTypes.oneOfType([
+  dataSets: PropTypes.arrayOf(
+    PropTypes.shape({
+      values: PropTypes.arrayOf(
         PropTypes.shape({
           x: PropTypes.number,
           y: PropTypes.number.isRequired,
-          marker: PropTypes.string,
-        }),
-        PropTypes.number
-      ])
-    ),
-    label: PropTypes.string.isRequired,
-    config: PropTypes.shape({
-      ...ChartDataSetConfig.common,
-      ...ChartDataSetConfig.barLineScatterCandleBubble,
-      ...ChartDataSetConfig.lineScatterCandleRadar,
-
-      scatterShapeSize: PropTypes.number,
-      scatterShape: PropTypes.oneOf(['SQUARE', 'CIRCLE', 'TRIANGLE', 'CROSS', 'X']),
-      scatterShapeHoleColor: PropTypes.number,
-      scatterShapeHoleRadius: PropTypes.number
+          size: PropTypes.number.isRequired,
+          marker: PropTypes.string
+        })
+      ),
+      label: PropTypes.string.isRequired,
+      config: PropTypes.shape({
+        ...ChartDataSetConfig.common,
+        ...ChartDataSetConfig.barLineScatterCandleBubble
+      })
     })
-  }))
-})
+  )
+});
+
+const candleData = PropTypes.shape({
+  dataSets: PropTypes.arrayOf(
+    PropTypes.shape({
+      values: PropTypes.arrayOf(
+        PropTypes.shape({
+          x: PropTypes.number,
+          shadowH: PropTypes.number.isRequired,
+          shadowL: PropTypes.number.isRequired,
+          open: PropTypes.number.isRequired,
+          close: PropTypes.number.isRequired,
+          marker: PropTypes.string
+        })
+      ),
+      label: PropTypes.string.isRequired,
+      config: PropTypes.shape({
+        ...ChartDataSetConfig.common,
+        ...ChartDataSetConfig.barLineScatterCandleBubble,
+        ...ChartDataSetConfig.lineScatterCandleRadar,
+
+        barSpace: PropTypes.number,
+        shadowWidth: PropTypes.number,
+        shadowColor: PropTypes.number,
+        shadowColorSameAsCandle: PropTypes.bool,
+        neutralColor: PropTypes.number,
+        decreasingColor: PropTypes.number,
+        decreasingPaintStyle: PropTypes.oneOf([
+          "FILL",
+          "STROKE",
+          "FILL_AND_STROKE"
+        ]),
+        increasingColor: PropTypes.number,
+        increasingPaintStyle: PropTypes.oneOf([
+          "FILL",
+          "STROKE",
+          "FILL_AND_STROKE"
+        ])
+      })
+    })
+  )
+});
+
+const pieData = PropTypes.shape({
+  dataSets: PropTypes.arrayOf(
+    PropTypes.shape({
+      values: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.shape({
+            value: PropTypes.number.isRequired,
+            label: PropTypes.string
+          }),
+          PropTypes.number
+        ])
+      ),
+      label: PropTypes.string.isRequired,
+      config: PropTypes.shape({
+        ...ChartDataSetConfig.common,
+
+        sliceSpace: PropTypes.number,
+        selectionShift: PropTypes.number,
+        xValuePosition: PropTypes.oneOf(["INSIDE_SLICE", "OUTSIDE_SLICE"]),
+        yValuePosition: PropTypes.oneOf(["INSIDE_SLICE", "OUTSIDE_SLICE"]),
+        valueLinePart1Length: PropTypes.number,
+        valueLinePart2Length: PropTypes.number,
+        valueLineColor: PropTypes.number,
+        valueLineWidth: PropTypes.number,
+        valueLinePart1OffsetPercentage: PropTypes.number,
+        valueLineVariableLength: PropTypes.bool
+      })
+    })
+  )
+});
+
+const radarData = PropTypes.shape({
+  dataSets: PropTypes.arrayOf(
+    PropTypes.shape({
+      values: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.shape({ value: PropTypes.number.isRequired }),
+          PropTypes.number
+        ])
+      ),
+      label: PropTypes.string.isRequired,
+      config: PropTypes.shape({
+        ...ChartDataSetConfig.common,
+        ...ChartDataSetConfig.lineScatterCandleRadar,
+        ...ChartDataSetConfig.lineRadar
+      })
+    })
+  ),
+  labels: PropTypes.arrayOf(PropTypes.string)
+});
+
+const scatterData = PropTypes.shape({
+  dataSets: PropTypes.arrayOf(
+    PropTypes.shape({
+      values: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.shape({
+            x: PropTypes.number,
+            y: PropTypes.number.isRequired,
+            marker: PropTypes.string
+          }),
+          PropTypes.number
+        ])
+      ),
+      label: PropTypes.string.isRequired,
+      config: PropTypes.shape({
+        ...ChartDataSetConfig.common,
+        ...ChartDataSetConfig.barLineScatterCandleBubble,
+        ...ChartDataSetConfig.lineScatterCandleRadar,
+
+        scatterShapeSize: PropTypes.number,
+        scatterShape: PropTypes.oneOf([
+          "SQUARE",
+          "CIRCLE",
+          "TRIANGLE",
+          "CROSS",
+          "X"
+        ]),
+        scatterShapeHoleColor: PropTypes.number,
+        scatterShapeHoleRadius: PropTypes.number
+      })
+    })
+  )
+});
 
 const combinedData = PropTypes.shape({
   lineData: lineData,
@@ -207,6 +246,15 @@ const combinedData = PropTypes.shape({
   scatterData: scatterData,
   candleData: candleData,
   bubbleData: bubbleData
-})
+});
 
-export {lineData, barData, pieData, bubbleData, scatterData, candleData, radarData, combinedData};
+export {
+  lineData,
+  barData,
+  pieData,
+  bubbleData,
+  scatterData,
+  candleData,
+  radarData,
+  combinedData
+};


### PR DESCRIPTION
### Changes
**Implement Image instead of circles for data points in LineCharts**

### How to use
1. Pass resolved Image, width size, height size on LineData Props
2. Should resolve image through Image.resolveAssetSource()

```javascript
// refer to https://stackoverflow.com/a/50894993/12330603
function convertImageToImageBundleForNativeModule(image: any): any {
  return Image.resolveAssetSource(image);
}
 ```

### updated interface for LineData:
```javascript 
const lineData = PropTypes.shape({
  dataSets: PropTypes.arrayOf(
    PropTypes.shape({
      values: PropTypes.arrayOf(
        PropTypes.oneOfType([
          PropTypes.shape({
            x: PropTypes.number,
            y: PropTypes.number.isRequired,
            marker: PropTypes.string,
           // props for image
            icon: PropTypes.shape({
              bundle: PropTypes.object,
              width: PropTypes.number,
              height: PropTypes.number
            })
          //////
          }),
          PropTypes.number
        ])
      ),
      label: PropTypes.string.isRequired,
...
```


### Screens
| Android  | iOS |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/20822017/71245779-c8bac900-2358-11ea-837e-1bc54d959cba.png) |  ![image](https://user-images.githubusercontent.com/20822017/71245732-b2ad0880-2358-11ea-9e16-6df0ac9b996d.png) |






### Related Issue
 #371 