### PR TITLE
Update README.md

### DIFF
--- a/installation_guide/README.md
+++ b/installation_guide/README.md
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
 
 #### 1. update android/build.gradle, upgrade gradle tools version, add jitpack.io
 
-add `maven { url "https://jitpack.io" }` under allprojects -> repositories if it is absent, IT IS USED BY MPAndroidChart
+add `maven { url "https://jitpack.io" }` as **the last entry** under allprojects -> repositories if it is absent, IT IS USED BY MPAndroidChart
 
 make sure compileSdkVersion >= 28
 


### PR DESCRIPTION
Add important notice which, if not followed, can lead to Android error:
```
Annotation processors must be explicitly declared now.  The following dependencies on the compile classpath are found to contain annotation processor.  Please add them to the annotationProcessor configuration.
  - moxy-compiler-2.0.2.jar (com.github.moxy-community.moxy:moxy-compiler:2.0.2)
Alternatively, set android.defaultConfig.javaCompileOptions.annotationProcessorOptions.includeCompileClasspath = true to continue with previous behavior.  Note that this option is deprecated and will be removed in the future.
See https://developer.android.com/r/tools/annotation-processor-error-message.html for more details..
```

I've taken solution from https://github.com/permissions-dispatcher/PermissionsDispatcher/issues/535#issuecomment-432190926