### PR TITLE
Add reference to drawOrder to README

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -160,9 +160,10 @@
 
 #### _BarLineChartBase props plus props listed below_.
 
-| Prop   | Type                     | Default | Note |
-| ------ | ------------------------ | ------- | ---- |
-| `data` | `DataTypes.combinedData` |         |      |
+| Prop        | Type                                                 | Default | Note |
+| ------      | ---------------------------------------------------- | ------- | ---- |
+| `data`      | `DataTypes.combinedData`                             |         |      |
+| `drawOrder` | `array with one of: ['SCATTER', 'BAR', 'LINE']`      |         |      |
 
 ## HorizontalBarChart
 


### PR DESCRIPTION
A prop editing the order (zIndex) in which charts are drawn on the CombinedChart has been added in 0.5.5, but not mentioned in the docs.
This commit fixes that.