### PR TITLE
Add more supported onChange events including gesture/pan end

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,28 @@ index will used as x.
 check Example->TimeSeriesLineChart for details
 
 
-## Callback
+## Supported Callbacks
 
-**Support value selection callBack: onSelect**
+**onSelect**
 
-you can do whatever you want, even pop your own modal, or jump to another page.
+Triggered when a chart value is selected. The event passed back will include the coordinates of the touch as well as the data (including marker label) selected.
 
-**Support gesture callBack: onChange**
+**onChange**
+
+Triggered for various supported events on each platform. Due to the different nature of gesture handling on each platform as well as the different implementations of the underlying chart libraries, the same events are not supported on every platform. For full details on the supported events, see the table below:
+
+| Event Name | Description | iOS | Android |
+| --------------- | -------- | ------- | ---- |
+| `chartScaled`       | When a chart is scaled/zoomed via a pinch zoom gesture. | ✅ | ✅ |
+| `chartTranslated`   | When a chart is moved/translated via a drag gesture. | ✅ | ✅ |
+| `chartPanEnd`       | When a chart pan gesture ends. | ✅ | ❌ |
+| `chartGestureStart` | When a chart gesture starts. | ❌ | ✅ |
+| `chartGestureEnd`   | When a chart gesture ends. | ❌ | ✅ |
+| `chartLongPress`    | When a chart is long pressed. | ❌ | ✅ |
+| `chartSingleTap`    | When a chart is single tapped. | ❌ | ✅ |
+| `chartFling`        | When a chart recieves a fling gesture. | ❌ | ✅ |
+| `doubleTapped`      | When a chart is double tapped | ❌ | ✅ |
+
 
 check Example->MultipleChart for details.
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -43,14 +43,17 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
 
     @Override
     public void onChartGestureStart(MotionEvent me, ChartTouchListener.ChartGesture lastPerformedGesture) {
+        sendEvent("chartGestureStart", me);
     }
 
     @Override
     public void onChartGestureEnd(MotionEvent me, ChartTouchListener.ChartGesture lastPerformedGesture) {
+        sendEvent("chartGestureEnd", me);
     }
 
     @Override
     public void onChartLongPressed(MotionEvent me) {
+        sendEvent("chartLongPress", me);
     }
 
     @Override
@@ -60,10 +63,12 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
 
     @Override
     public void onChartSingleTapped(MotionEvent me) {
+        sendEvent("chartSingleTap", me);
     }
 
     @Override
     public void onChartFling(MotionEvent me1, MotionEvent me2, float velocityX, float velocityY) {
+        sendEvent("chartFling", me1);
     }
 
     @Override

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -498,6 +498,10 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         sendEvent("chartTranslated")
     }
 
+    @objc public func chartViewDidEndPanning(_ chartView: ChartViewBase) {
+        sendEvent("chartPanEnd")
+    }
+
     func sendEvent(_ action:String) {
         var dict = [AnyHashable: Any]()
 


### PR DESCRIPTION
With some of these events it will give the ability to hide the indicators without the need to wrap the chart in gesture handlers or pan responders.