### PR TITLE
Using ViewPropTypes from another package

### DIFF
--- a/lib/ChartBase.js
+++ b/lib/ChartBase.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
-import {
-  ViewPropTypes
-} from 'react-native';
 
 import {xAxisIface} from './AxisIface'
+import {ViewPropTypes} from "deprecated-react-native-prop-types";
 
 const descriptionIface = {
   text: PropTypes.string,

--- a/package.json
+++ b/package.json
@@ -21,17 +21,18 @@
   "files": [
     "android/src",
     "android/build.gradle",
-    "android/gradle.properties",    
+    "android/gradle.properties",
     "ios/**/*.h",
     "ios/**/*.m",
-    "ios/**/*.swift",    
+    "ios/**/*.swift",
     "lib",
     "index.js",
     "react-native-charts-wrapper.podspec",
     "ios/ReactNativeCharts/ReactNativeCharts.xcodeproj/project.pbxproj"
   ],
   "dependencies": {
-    "prop-types": "15.7.2",
+    "deprecated-react-native-prop-types": "^2.3.0",
+    "prop-types": "^15.8.1",
     "react": "16.13.1"
   }
 }


### PR DESCRIPTION
This small PR adds compatibilty with React Native 0.69.0, by using the ViewPropTypes from the `deprecated-react-native-prop-types` package instead of RN directly. This was a change recently introduced by RN.