### PR TITLE
Add yAxis left/right config details to docs.md

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -84,6 +84,8 @@
 | Prop          | Type                                                                                  | Default | Note |
 | ------------- | ------------------------------------------------------------------------------------- | ------- | ---- |
 | `inverted`    | `number`                                                                              |         |      |
+| `left`			  | `config`                                                                              |         | Applies config to left line      |
+| `right`		    | `config`                                                                              |         | Applies config to right line     |
 | `spaceTop`    | `bool`                                                                                |         |      |
 | `spaceBottom` | `number`                                                                              |         |      |
 | `position`    | `number`                                                                              |         |      |


### PR DESCRIPTION
The docs fail to mention that yAxis configuration must be written inside a `left` or `right` prop. I added that info to the yAxis section. although more clarification may still be needed.