### PR TITLE
Upgrade library from Charts to DGCharts latest version

### DIFF
--- a/ios/ReactNativeCharts/BalloonMarker.swift
+++ b/ios/ReactNativeCharts/BalloonMarker.swift
@@ -14,7 +14,7 @@
 
 import Foundation;
 
-import Charts;
+import DGCharts;
 
 import SwiftyJSON;
 
@@ -25,10 +25,10 @@ open class BalloonMarker: MarkerView {
     open var textColor: UIColor?
     open var minimumSize = CGSize()
 
-    
+
     fileprivate var insets = UIEdgeInsets(top: 8.0,left: 8.0,bottom: 20.0,right: 8.0)
     fileprivate var topInsets = UIEdgeInsets(top: 20.0,left: 8.0,bottom: 8.0,right: 8.0)
-    
+
     fileprivate var labelns: NSString?
     fileprivate var _labelSize: CGSize = CGSize()
     fileprivate var _size: CGSize = CGSize()
@@ -59,9 +59,9 @@ open class BalloonMarker: MarkerView {
 
 
         var rect = CGRect(origin: point, size: _size)
-        
+
         if point.y - _size.height < 0 {
-          
+
             if point.x - _size.width / 2.0 < 0 {
                 drawTopLeftRect(context: context, rect: rect)
             } else if (chart != nil && point.x + width - _size.width / 2.0 > (chart?.bounds.width)!) {
@@ -71,14 +71,14 @@ open class BalloonMarker: MarkerView {
                 rect.origin.x -= _size.width / 2.0
                 drawTopCenterRect(context: context, rect: rect)
             }
-            
+
             rect.origin.y += self.topInsets.top
             rect.size.height -= self.topInsets.top + self.topInsets.bottom
 
         } else {
-            
+
             rect.origin.y -= _size.height
-            
+
             if point.x - _size.width / 2.0 < 0 {
                 drawLeftRect(context: context, rect: rect)
             } else if (chart != nil && point.x + width - _size.width / 2.0 > (chart?.bounds.width)!) {
@@ -88,12 +88,12 @@ open class BalloonMarker: MarkerView {
                 rect.origin.x -= _size.width / 2.0
                 drawCenterRect(context: context, rect: rect)
             }
-            
+
             rect.origin.y += self.insets.top
             rect.size.height -= self.insets.top + self.insets.bottom
 
         }
-        
+
         return rect
     }
 
@@ -138,9 +138,9 @@ open class BalloonMarker: MarkerView {
         context.fillPath()
 
     }
-    
+
     func drawTopCenterRect(context: CGContext, rect: CGRect) {
-        
+
         context.setFillColor((color?.cgColor)!)
         context.beginPath()
         context.move(to: CGPoint(x: rect.origin.x + rect.size.width / 2.0, y: rect.origin.y))
@@ -152,7 +152,7 @@ open class BalloonMarker: MarkerView {
         context.addLine(to: CGPoint(x: rect.origin.x + (rect.size.width - arrowSize.width) / 2.0, y: rect.origin.y + arrowSize.height))
         context.addLine(to: CGPoint(x: rect.origin.x + rect.size.width / 2.0, y: rect.origin.y))
         context.fillPath()
-        
+
     }
 
     func drawTopLeftRect(context: CGContext, rect: CGRect) {
@@ -215,7 +215,7 @@ open class BalloonMarker: MarkerView {
         if let object = entry.data as? JSON {
             if object["marker"].exists() {
                 label = object["marker"].stringValue;
-              
+
                 if highlight.stackIndex != -1 && object["marker"].array != nil {
                     label = object["marker"].arrayValue[highlight.stackIndex].stringValue
                 }

--- a/ios/ReactNativeCharts/ChartGroupHolder.swift
+++ b/ios/ReactNativeCharts/ChartGroupHolder.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-import Charts
+import DGCharts
 
 class ChartHolder {
     open weak var chart:BarLineChartViewBase?
     open var syncX: Bool;
     open  var syncY:Bool;
-    
+
     init( chart: BarLineChartViewBase,  syncX: Bool,  syncY: Bool) {
         self.chart = chart
         self.syncX = syncX
@@ -23,45 +23,45 @@ class ChartHolder {
 
 open class ChartGroupHolder {
     static var chartGroup: Dictionary<String, Dictionary<String, ChartHolder>> = [:]
-    
+
     public static func addChart(group: String, identifier: String ,  chart: BarLineChartViewBase,  syncX: Bool, syncY: Bool) {
         objc_sync_enter(chartGroup)
         defer { objc_sync_exit(chartGroup) }
-        
+
         let keyExists = chartGroup[group] != nil
-        
+
         if !keyExists {
             chartGroup[group] = [:]
         }
-        
+
         chartGroup[group]![identifier] = ChartHolder(chart: chart, syncX: syncX, syncY: syncY)
     }
-    
-    
+
+
     // sync gesture to other chart in the same group
     public static func sync( group: String,  identifier: String,  scaleX: CGFloat,  scaleY:CGFloat,  centerX: CGFloat,  centerY:CGFloat,  performImmediately: Bool) {
-        
+
         objc_sync_enter(chartGroup)
         defer { objc_sync_exit(chartGroup) }
-        
+
         if let identifierMap = chartGroup[group] {
             for (identifierKey, chartHolder) in identifierMap {
                 if identifierKey != identifier {
                     if let chart = chartHolder.chart {
-                        
+
                         let axis = chart.getAxis(YAxis.AxisDependency.left).enabled ? YAxis.AxisDependency.left : YAxis.AxisDependency.right
-                        
+
                         let contentRect = chart.contentRect
-                        
+
                         let originalCenterValue = chart.valueForTouchPoint(point: CGPoint(x: contentRect.midX, y: contentRect.midY), axis: axis)
 
                         let finalScaleX = chartHolder.syncX ? scaleX : chart.scaleX
                         let finalScaleY = chartHolder.syncY ? scaleY : chart.scaleY
-                        
+
                         let finalCenterX = chartHolder.syncX ? centerX : originalCenterValue.x;
                         let finalCenterY = chartHolder.syncY ? centerY : originalCenterValue.y;
-                        
-                        chart.zoom(scaleX: finalScaleX, scaleY: finalScaleY, xValue: Double(finalCenterX), yValue: Double(finalCenterY), axis: axis);                        
+
+                        chart.zoom(scaleX: finalScaleX, scaleY: finalScaleY, xValue: Double(finalCenterX), yValue: Double(finalCenterY), axis: axis);
                     }
                 }
             }

--- a/ios/ReactNativeCharts/CircleMarker.swift
+++ b/ios/ReactNativeCharts/CircleMarker.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Charts
+import DGCharts
 
 open class CircleMarker: MarkerImage
 {

--- a/ios/ReactNativeCharts/ConfigurableMinimumLinePositionFillFormatter.swift
+++ b/ios/ReactNativeCharts/ConfigurableMinimumLinePositionFillFormatter.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Charts
+import DGCharts
 
 open class ConfigurableMinimumLinePositionFillFormatter: NSObject, FillFormatter {
 

--- a/ios/ReactNativeCharts/CustomChartDateFormatter.swift
+++ b/ios/ReactNativeCharts/CustomChartDateFormatter.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Charts
+import DGCharts
 
 open class CustomChartDateFormatter: NSObject, ValueFormatter, AxisValueFormatter {
 

--- a/ios/ReactNativeCharts/DataExtract.swift
+++ b/ios/ReactNativeCharts/DataExtract.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import Charts
+import DGCharts
 import SwiftyJSON
 
 open class DataExtract {

--- a/ios/ReactNativeCharts/IndexValueFormatter.swift
+++ b/ios/ReactNativeCharts/IndexValueFormatter.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-import Charts
+import DGCharts
 
 open class IndexValueFormatter: NSObject, ValueFormatter {
 

--- a/ios/ReactNativeCharts/RNBarLineChartBaseManager.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartBaseManager.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-import Charts
+import DGCharts
 
 protocol RNBarLineChartBaseManager {
   var _bridge : RCTBridge? {get}
@@ -17,42 +17,42 @@ extension RNBarLineChartBaseManager {
       (view.chart as! BarLineChartViewBase).moveViewToX(xValue.doubleValue);
     }
   }
-  
+
   func _moveViewTo(_ reactTag: NSNumber, xValue: NSNumber, yValue: NSNumber, axisDependency: NSString) {
     _bridge?.uiManager.addUIBlock { (uiManager: RCTUIManager?, viewRegistry:[NSNumber : UIView]?) in
       let view: RNBarLineChartViewBase = viewRegistry![reactTag] as! RNBarLineChartViewBase;
       (view.chart as! BarLineChartViewBase).moveViewTo(xValue: xValue.doubleValue, yValue: yValue.doubleValue, axis: BridgeUtils.parseAxisDependency(axisDependency as String));
     }
   }
-  
+
   func _moveViewToAnimated(_ reactTag: NSNumber, xValue: NSNumber, yValue: NSNumber, axisDependency: NSString, duration: NSNumber) {
     _bridge?.uiManager.addUIBlock { (uiManager: RCTUIManager?, viewRegistry:[NSNumber : UIView]?) in
       let view: RNBarLineChartViewBase = viewRegistry![reactTag] as! RNBarLineChartViewBase;
       (view.chart as! BarLineChartViewBase).moveViewToAnimated(xValue: xValue.doubleValue, yValue: yValue.doubleValue, axis: BridgeUtils.parseAxisDependency(axisDependency as String), duration: duration.doubleValue / 1000.0);
     }
   }
-  
+
   func _centerViewTo(_ reactTag: NSNumber, xValue: NSNumber, yValue: NSNumber, axisDependency: NSString) {
     _bridge?.uiManager.addUIBlock { (uiManager: RCTUIManager?, viewRegistry:[NSNumber : UIView]?) in
       let view: RNBarLineChartViewBase = viewRegistry![reactTag] as! RNBarLineChartViewBase;
       (view.chart as! BarLineChartViewBase).centerViewTo(xValue: xValue.doubleValue, yValue: yValue.doubleValue, axis: BridgeUtils.parseAxisDependency(axisDependency as String));
     }
   }
-  
+
   func _centerViewToAnimated(_ reactTag: NSNumber, xValue: NSNumber, yValue: NSNumber, axisDependency: NSString, duration: NSNumber) {
     _bridge?.uiManager.addUIBlock { (uiManager: RCTUIManager?, viewRegistry:[NSNumber : UIView]?) in
       let view: RNBarLineChartViewBase = viewRegistry![reactTag] as! RNBarLineChartViewBase;
       (view.chart as! BarLineChartViewBase).centerViewToAnimated(xValue: xValue.doubleValue, yValue: yValue.doubleValue, axis: BridgeUtils.parseAxisDependency(axisDependency as String), duration: duration.doubleValue / 1000.0);
     }
   }
-  
+
   func _fitScreen(_ reactTag: NSNumber) {
     _bridge?.uiManager.addUIBlock { (uiManager: RCTUIManager?, viewRegistry:[NSNumber : UIView]?) in
       let view: RNBarLineChartViewBase = viewRegistry![reactTag] as! RNBarLineChartViewBase;
       (view.chart as! BarLineChartViewBase).fitScreen();
     }
   }
-  
+
   func _highlights(_ reactTag: NSNumber, config: NSArray) {
     _bridge?.uiManager.addUIBlock { (uiManager: RCTUIManager?, viewRegistry:[NSNumber : UIView]?) in
       let view: RNBarLineChartViewBase = viewRegistry![reactTag] as! RNBarLineChartViewBase;

--- a/ios/ReactNativeCharts/RNBarLineChartManagerBridge.h
+++ b/ios/ReactNativeCharts/RNBarLineChartManagerBridge.h
@@ -15,6 +15,7 @@ RCT_EXPORT_VIEW_PROPERTY(borderColor, NSInteger) \
 RCT_EXPORT_VIEW_PROPERTY(borderWidth, CGFloat) \
 RCT_EXPORT_VIEW_PROPERTY(maxVisibleValueCount, NSInteger) \
 RCT_EXPORT_VIEW_PROPERTY(visibleRange, NSDictionary) \
+RCT_EXPORT_VIEW_PROPERTY(maxScale, NSDictionary) \
 RCT_EXPORT_VIEW_PROPERTY(autoScaleMinMaxEnabled, BOOL) \
 RCT_EXPORT_VIEW_PROPERTY(keepPositionOnRotation, BOOL) \
 RCT_EXPORT_VIEW_PROPERTY(scaleEnabled, BOOL) \

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -138,6 +138,20 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         }
     }
 
+    func setMaxScale(_ config: NSDictionary) {
+        let json = BridgeUtils.toJson(config)
+
+        let maxScaleX = json["x"]
+        if maxScaleX.double != nil {
+            barLineChart.viewPortHandler.setMaximumScaleX(maxScaleX.doubleValue)
+        }
+
+        let maxScaleY = json["y"]
+        if maxScaleY.double != nil {
+            barLineChart.viewPortHandler.setMaximumScaleY(maxScaleY.doubleValue)
+        }
+    }
+
     func setAutoScaleMinMaxEnabled(_  enabled: Bool) {
         barLineChart.autoScaleMinMaxEnabled = enabled
     }

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNBarLineChartViewBase: RNYAxisChartViewBase {
@@ -13,11 +13,11 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
             return chart as! BarLineChartViewBase
         }
     }
-    
+
     var savedVisibleRange : NSDictionary?
 
     var savedZoom : NSDictionary?
-  
+
     var _onYaxisMinMaxChange : RCTBubblingEventBlock?
     var timer : Timer?
 
@@ -44,12 +44,12 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
       if callback == nil {
         return;
       }
-      
+
       var lastMin: Double = 0;
       var lastMax: Double = 0;
-      
+
       let axis = (self.chart as! BarLineChartViewBase).getAxis(.right);
-        
+
       if #available(iOS 10.0, *) {
         // Interval for 16ms
         self.timer = Timer.scheduledTimer(withTimeInterval: 1/60, repeats: true) { timer in
@@ -57,7 +57,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
           let maximum = axis.axisMaximum;
           if lastMin != minimum || lastMax != maximum {
             print("Update the view", minimum, lastMin, maximum, lastMax)
-            
+
             guard let callback = self._onYaxisMinMaxChange else {
               return;
             }
@@ -93,7 +93,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
     }
 
     func setBorderColor(_ color: Int) {
-        
+
         barLineChart.borderColor = RCTConvert.uiColor(color);
     }
 
@@ -105,15 +105,15 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
     func setMaxVisibleValueCount(_ count: NSInteger) {
         barLineChart.maxVisibleCount = count;
     }
-    
+
     func setVisibleRange(_ config: NSDictionary) {
         // delay visibleRange handling until chart data is set
         savedVisibleRange = config
     }
-    
+
     func updateVisibleRange(_ config: NSDictionary) {
         let json = BridgeUtils.toJson(config)
-        
+
         let x = json["x"]
         if x["min"].double != nil {
             barLineChart.setVisibleXRangeMinimum(x["min"].doubleValue)
@@ -121,7 +121,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         if x["max"].double != nil {
             barLineChart.setVisibleXRangeMaximum(x["max"].doubleValue)
         }
-        
+
         let y = json["y"]
         if y["left"]["min"].double != nil {
             barLineChart.setVisibleYRangeMinimum(y["left"]["min"].doubleValue, axis: YAxis.AxisDependency.left)
@@ -129,7 +129,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         if y["left"]["max"].double != nil {
             barLineChart.setVisibleYRangeMaximum(y["left"]["max"].doubleValue, axis: YAxis.AxisDependency.left)
         }
-        
+
         if y["right"]["min"].double != nil {
             barLineChart.setVisibleYRangeMinimum(y["right"]["min"].doubleValue, axis: YAxis.AxisDependency.right)
         }
@@ -137,7 +137,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
             barLineChart.setVisibleYRangeMaximum(y["right"]["max"].doubleValue, axis: YAxis.AxisDependency.right)
         }
     }
-    
+
     func setAutoScaleMinMaxEnabled(_  enabled: Bool) {
         barLineChart.autoScaleMinMaxEnabled = enabled
     }
@@ -188,7 +188,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
             if json["axisDependency"].string != nil && json["axisDependency"].stringValue == "RIGHT" {
                 axisDependency = YAxis.AxisDependency.right
             }
-            
+
             barLineChart.zoom(scaleX: CGFloat(json["scaleX"].floatValue),
                     scaleY: CGFloat(json["scaleY"].floatValue),
                     xValue: json["xValue"].doubleValue,
@@ -210,15 +210,15 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
 
     func setExtraOffsets(_ config: NSDictionary) {
         let json = BridgeUtils.toJson(config)
-    
+
         let left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
         let top = json["top"].double != nil ? CGFloat(json["top"].doubleValue) : 0
         let right = json["right"].double != nil ? CGFloat(json["right"].doubleValue) : 0
         let bottom = json["bottom"].double != nil ? CGFloat(json["bottom"].doubleValue) : 0
-    
+
         barLineChart.setExtraOffsets(left: left, top: top, right: right, bottom: bottom)
     }
-    
+
     override func onAfterDataSetChanged() {
         super.onAfterDataSetChanged()
 
@@ -246,10 +246,10 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         let originalVisibleYRange = getVisibleYRange(axis)
 
         barLineChart.fitScreen()
-        
+
         barLineChart.data = dataExtract.extract(json)
         barLineChart.notifyDataSetChanged()
-        
+
 
         let newVisibleXRange = barLineChart.visibleXRange
         let newVisibleYRange = getVisibleYRange(axis)
@@ -262,13 +262,13 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         // but in android MpAndroidChart, ZoomJob getInstance(viewPortHandler, scaleX, scaleY, xValue, yValue, trans, axis, v)
         // the scale is relative scale, touchMatrix.scaleX = touchMatrix.scaleX * scaleX
         // so in iOS, we updateVisibleRange after zoom
-        
+
         barLineChart.zoom(scaleX: CGFloat(scaleX), scaleY: CGFloat(scaleY), xValue: Double(originCenterValue.x), yValue: Double(originCenterValue.y), axis: axis)
-        
+
         if let config = savedVisibleRange {
             updateVisibleRange(config)
         }
-        barLineChart.notifyDataSetChanged()        
+        barLineChart.notifyDataSetChanged()
     }
 
     func getVisibleYRange(_ axis: YAxis.AxisDependency) -> CGFloat {
@@ -276,5 +276,5 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
 
         return barLineChart.valueForTouchPoint(point: CGPoint(x: contentRect.maxX, y:contentRect.minY), axis: axis).y - barLineChart.valueForTouchPoint(point: CGPoint(x: contentRect.minX, y:contentRect.maxY), axis: axis).y
     }
-    
+
 }

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import Charts
+import DGCharts
 import SwiftyJSON
 
 // In react native, because object-c is unaware of swift protocol extension. use baseClass as workaround
@@ -46,14 +46,14 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         let json = BridgeUtils.toJson(data)
 
         let extractedChartData: ChartData? = dataExtract.extract(json)
-        
+
         guard let chartData = extractedChartData else { return }
-    
-        // https://github.com/danielgindi/Charts/issues/4690    
+
+        // https://github.com/danielgindi/Charts/issues/4690
         let originValueFormatters = chartData.map {$0.valueFormatter}
-        
+
         chart.data = chartData
-            
+
         for (set, valueFormatter) in zip(chartData, originValueFormatters) {
             set.valueFormatter = valueFormatter
         }

--- a/ios/ReactNativeCharts/RNYAxisChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNYAxisChartViewBase.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNYAxisChartViewBase: RNChartViewBase {

--- a/ios/ReactNativeCharts/bar/BarDataExtract.swift
+++ b/ios/ReactNativeCharts/bar/BarDataExtract.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 import SwiftyJSON
-import Charts
+import DGCharts
 
 class BarDataExtract : DataExtract {
     override open func createData() -> ChartData {

--- a/ios/ReactNativeCharts/bar/RNBarChartView.swift
+++ b/ios/ReactNativeCharts/bar/RNBarChartView.swift
@@ -2,22 +2,22 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNBarChartView: RNBarChartViewBase {
 
     let _chart: BarChartView
     let _dataExtract : BarDataExtract
-    
+
     override var chart: BarChartView {
         return _chart
     }
-    
+
     override var dataExtract: DataExtract {
         return _dataExtract
     }
-    
+
     override init(frame: CoreGraphics.CGRect) {
 
         self._chart = BarChartView(frame: frame)

--- a/ios/ReactNativeCharts/bar/RNBarChartViewBase.swift
+++ b/ios/ReactNativeCharts/bar/RNBarChartViewBase.swift
@@ -2,7 +2,7 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNBarChartViewBase: RNBarLineChartViewBase {
@@ -20,7 +20,7 @@ class RNBarChartViewBase: RNBarLineChartViewBase {
     func setDrawBarShadow(_ enabled: Bool) {
         barChart.drawBarShadowEnabled = enabled
     }
-    
+
     func setHighlightFullBarEnabled(_ enabled: Bool) {
         barChart.highlightFullBarEnabled = enabled
     }

--- a/ios/ReactNativeCharts/bar/RNHorizontalBarChartView.swift
+++ b/ios/ReactNativeCharts/bar/RNHorizontalBarChartView.swift
@@ -2,33 +2,33 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNHorizontalBarChartView: RNBarChartViewBase {
 
     let _chart: HorizontalBarChartView
     let _dataExtract : BarDataExtract
-    
+
     override var chart: HorizontalBarChartView {
         return _chart
     }
-    
+
     override var dataExtract: DataExtract {
         return _dataExtract
     }
-    
+
     override init(frame: CoreGraphics.CGRect) {
-        
+
         self._chart = HorizontalBarChartView(frame: frame)
         self._dataExtract = BarDataExtract()
-        
+
         super.init(frame: frame)
-        
+
         self._chart.delegate = self
         self.addSubview(_chart)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/ios/ReactNativeCharts/bubble/BubbleDataExtract.swift
+++ b/ios/ReactNativeCharts/bubble/BubbleDataExtract.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 import SwiftyJSON
-import Charts
+import DGCharts
 
 class BubbleDataExtract : DataExtract {
     override func createData() -> ChartData {

--- a/ios/ReactNativeCharts/bubble/RNBubbleChartView.swift
+++ b/ios/ReactNativeCharts/bubble/RNBubbleChartView.swift
@@ -2,7 +2,7 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNBubbleChartView: RNBarLineChartViewBase {
@@ -12,11 +12,11 @@ class RNBubbleChartView: RNBarLineChartViewBase {
     override var chart: BubbleChartView {
         return _chart
     }
-    
+
     override var dataExtract: DataExtract {
         return _dataExtract
     }
-    
+
 
     override init(frame: CoreGraphics.CGRect) {
 
@@ -24,7 +24,7 @@ class RNBubbleChartView: RNBarLineChartViewBase {
         self._dataExtract = BubbleDataExtract()
 
         super.init(frame: frame)
-      
+
         self._chart.delegate = self
         self.addSubview(_chart)
 

--- a/ios/ReactNativeCharts/candlestick/CandleDataExtract.swift
+++ b/ios/ReactNativeCharts/candlestick/CandleDataExtract.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import SwiftyJSON
-import Charts
+import DGCharts
 
 class CandleDataExtract : DataExtract {
     override func createData() -> ChartData {

--- a/ios/ReactNativeCharts/candlestick/RNCandleStickChartView.swift
+++ b/ios/ReactNativeCharts/candlestick/RNCandleStickChartView.swift
@@ -2,38 +2,38 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNCandleStickChartView: RNBarLineChartViewBase {
-    
+
     let _chart: CandleStickChartView;
     let _dataExtract : CandleDataExtract;
-    
+
     override var chart: ChartViewBase {
         return _chart
     }
-    
+
     override var dataExtract: DataExtract {
         return _dataExtract
     }
-    
-    
+
+
     override init(frame: CoreGraphics.CGRect) {
-        
+
         self._chart = CandleStickChartView(frame: frame)
         self._dataExtract = CandleDataExtract()
-        
+
         super.init(frame: frame);
-      
+
         self._chart.delegate = self
         self.addSubview(_chart);
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    
+
+
 
 }

--- a/ios/ReactNativeCharts/combine/CombinedDataExtract.swift
+++ b/ios/ReactNativeCharts/combine/CombinedDataExtract.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 import SwiftyJSON
-import Charts
+import DGCharts
 
 class CombinedDataExtract : DataExtract {
     let lineDataExtract = LineDataExtract()

--- a/ios/ReactNativeCharts/combine/RNCombinedChartView.swift
+++ b/ios/ReactNativeCharts/combine/RNCombinedChartView.swift
@@ -2,7 +2,7 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNCombinedChartView: RNBarLineChartViewBase {
@@ -13,10 +13,10 @@ class RNCombinedChartView: RNBarLineChartViewBase {
     override var chart: CombinedChartView {
         return _chart
     }
-    
+
     override var dataExtract: DataExtract {
         return _dataExtract
-    }    
+    }
 
     override init(frame: CoreGraphics.CGRect) {
 
@@ -32,7 +32,7 @@ class RNCombinedChartView: RNBarLineChartViewBase {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     func setDrawOrder(_ config: NSArray) {
         var array : [Int] = []
         for object in RCTConvert.nsStringArray(config) {
@@ -40,7 +40,7 @@ class RNCombinedChartView: RNBarLineChartViewBase {
         }
         _chart.drawOrder = array
     }
-    
+
     func setDrawValueAboveBar(_ enabled: Bool) {
         _chart.drawValueAboveBarEnabled = enabled
     }

--- a/ios/ReactNativeCharts/formatters/ChartDateFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/ChartDateFormatter.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import Charts
+import DGCharts
 
 open class ChartDateFormatter: NSObject, ValueFormatter, AxisValueFormatter {
 

--- a/ios/ReactNativeCharts/formatters/LabelByXValueFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/LabelByXValueFormatter.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Charts
+import DGCharts
 
 open class LabelByXValueFormatter: NSObject, ValueFormatter, AxisValueFormatter {
 

--- a/ios/ReactNativeCharts/formatters/LargeValueFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/LargeValueFormatter.swift
@@ -4,7 +4,7 @@
 //  Copyright © 2016 dcg. All rights reserved.
 //
 import Foundation
-import Charts
+import DGCharts
 
 open class LargeValueFormatter: NSObject, ValueFormatter, AxisValueFormatter
 {

--- a/ios/ReactNativeCharts/line/LineDataExtract.swift
+++ b/ios/ReactNativeCharts/line/LineDataExtract.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 import SwiftyJSON
-import Charts
+import DGCharts
 import UIKit
 
 class LineDataExtract : DataExtract {

--- a/ios/ReactNativeCharts/line/RNLineChartView.swift
+++ b/ios/ReactNativeCharts/line/RNLineChartView.swift
@@ -2,35 +2,35 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNLineChartView: RNBarLineChartViewBase {
     let _chart: LineChartView;
     let _dataExtract : LineDataExtract;
-    
+
     override var chart: LineChartView {
         return _chart
     }
-    
+
     override var dataExtract: DataExtract {
         return _dataExtract
     }
-    
+
     override init(frame: CoreGraphics.CGRect) {
-        
+
         self._chart = LineChartView(frame: frame)
         self._dataExtract = LineDataExtract()
-        
+
         super.init(frame: frame);
-        
+
         self._chart.delegate = self
         self.addSubview(_chart);
-        
+
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
 }

--- a/ios/ReactNativeCharts/pie/PieDataExtract.swift
+++ b/ios/ReactNativeCharts/pie/PieDataExtract.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 import SwiftyJSON
-import Charts
+import DGCharts
 
 class PieDataExtract : DataExtract {
     override func createData() -> ChartData {

--- a/ios/ReactNativeCharts/pie/RNPieChartView.swift
+++ b/ios/ReactNativeCharts/pie/RNPieChartView.swift
@@ -2,7 +2,7 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNPieChartView: RNChartViewBase {

--- a/ios/ReactNativeCharts/radar/RNRadarChartView.swift
+++ b/ios/ReactNativeCharts/radar/RNRadarChartView.swift
@@ -2,7 +2,7 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNRadarChartView: RNYAxisChartViewBase {
@@ -51,15 +51,15 @@ class RNRadarChartView: RNYAxisChartViewBase {
 
     func setExtraOffsets(_ config: NSDictionary) {
       let json = BridgeUtils.toJson(config)
-      
+
       let left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
       let top = json["top"].double != nil ? CGFloat(json["top"].doubleValue) : 0
       let right = json["right"].double != nil ? CGFloat(json["right"].doubleValue) : 0
       let bottom = json["bottom"].double != nil ? CGFloat(json["bottom"].doubleValue) : 0
-      
+
       chart.setExtraOffsets(left: left, top: top, right: right, bottom: bottom)
     }
-  
+
     func setRotationEnabled(_ enabled: Bool) {
         chart.rotationEnabled = enabled
     }
@@ -71,7 +71,7 @@ class RNRadarChartView: RNYAxisChartViewBase {
     func setDrawWeb(_ enabled: Bool) {
         chart.drawWeb = enabled
     }
-    
+
     func setWebLineWidth(_ width: NSNumber) {
         chart.webLineWidth = CGFloat(truncating: width)
     }

--- a/ios/ReactNativeCharts/radar/RadarDataExtract.swift
+++ b/ios/ReactNativeCharts/radar/RadarDataExtract.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 import SwiftyJSON
-import Charts
+import DGCharts
 
 class RadarDataExtract : DataExtract {
     override func createData() -> ChartData {

--- a/ios/ReactNativeCharts/scatter/RNScatterChartView.swift
+++ b/ios/ReactNativeCharts/scatter/RNScatterChartView.swift
@@ -2,7 +2,7 @@
 //  Copyright wuxudong
 //
 
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class RNScatterChartView: RNBarLineChartViewBase {
@@ -16,7 +16,7 @@ class RNScatterChartView: RNBarLineChartViewBase {
     override var dataExtract: DataExtract {
         return _dataExtract
     }
-    
+
     override init(frame: CoreGraphics.CGRect) {
 
         self._chart = ScatterChartView(frame: frame);
@@ -34,5 +34,5 @@ class RNScatterChartView: RNBarLineChartViewBase {
     }
 
 
-  
+
 }

--- a/ios/ReactNativeCharts/scatter/ScatterDataExtract.swift
+++ b/ios/ReactNativeCharts/scatter/ScatterDataExtract.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 import SwiftyJSON
-import Charts
+import DGCharts
 
 class ScatterDataExtract : DataExtract {
     override func createData() -> ChartData {

--- a/ios/ReactNativeCharts/utils/BridgeUtils.swift
+++ b/ios/ReactNativeCharts/utils/BridgeUtils.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 import SwiftyJSON
-import Charts
+import DGCharts
 
 class BridgeUtils {
     static func toIOSAlpha(_ alpha: NSNumber) -> CGFloat {

--- a/ios/ReactNativeCharts/utils/ChartDataSetConfigUtils.swift
+++ b/ios/ReactNativeCharts/utils/ChartDataSetConfigUtils.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import Charts
+import DGCharts
 import SwiftyJSON
 
 

--- a/ios/ReactNativeCharts/utils/EntryToDictionaryUtils.swift
+++ b/ios/ReactNativeCharts/utils/EntryToDictionaryUtils.swift
@@ -1,44 +1,44 @@
 //
 //  EntryToDictionaryUtils.swift
-//  
+//
 //
 //  Created by xudong wu on 08/03/2017.
 //  Copyright © 2017 Facebook. All rights reserved.
 //
 
 import UIKit
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class EntryToDictionaryUtils: NSObject {
   static func entryToDictionary(_ entry: ChartDataEntry) -> [AnyHashable: Any]{
     var dict = [AnyHashable: Any]()
-    
+
     if entry.data != nil {
         dict["data"] = (entry.data as! JSON).dictionaryObject!
     }
-    
-    if entry is BarChartDataEntry {        
+
+    if entry is BarChartDataEntry {
         let barEntry = entry as! BarChartDataEntry;
 
         dict["x"] = barEntry.x
-        
+
         if barEntry.yValues != nil {
             dict["yValues"] = barEntry.yValues
         } else {
             dict["y"] = barEntry.y
         }
     } else if entry is BubbleChartDataEntry {
-        
+
         let bubbleEntry = entry as! BubbleChartDataEntry;
-        
+
         dict["x"] = bubbleEntry.x
         dict["y"] = bubbleEntry.y
-        
+
         dict["size"] = bubbleEntry.size
     } else if entry is CandleChartDataEntry {
         let candleEntry = entry as! CandleChartDataEntry;
-        
+
         dict["x"] = candleEntry.x
         dict["open"] = candleEntry.open
         dict["close"] = candleEntry.close
@@ -46,21 +46,21 @@ class EntryToDictionaryUtils: NSObject {
         dict["high"] = candleEntry.high
     } else if entry is PieChartDataEntry {
         let pieEntry = entry as! PieChartDataEntry;
-        
+
         dict["value"] = pieEntry.value
-        
+
         if pieEntry.label != nil {
             dict["label"] = pieEntry.label!
-        }            
+        }
     } else if entry is RadarChartDataEntry {
         let radarEntry = entry as! RadarChartDataEntry;
-        
+
         dict["value"] = radarEntry.value
     } else {
         dict["x"] = entry.x
         dict["y"] = entry.y
     }
-    
+
     return dict
   }
 }

--- a/ios/ReactNativeCharts/utils/HighlightUtils.swift
+++ b/ios/ReactNativeCharts/utils/HighlightUtils.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Charts
+import DGCharts
 import SwiftyJSON
 
 class HighlightUtils {
@@ -15,27 +15,27 @@ class HighlightUtils {
     for object in config {
       if let dict = object as? NSDictionary {
         let json = BridgeUtils.toJson(dict)
-        
+
         if json["x"].double != nil {
           let dataSetIndex = json["dataSetIndex"].int != nil ? json["dataSetIndex"].intValue : 0
           let y = json["y"].double != nil ? json["y"].doubleValue : 0
-          
+
           var highlight : Highlight
           if json["stackIndex"].int != nil {
             highlight = Highlight(x: json["x"].doubleValue, dataSetIndex: dataSetIndex, stackIndex: json["stackIndex"].intValue)
           } else {
             highlight = Highlight(x: json["x"].doubleValue, y: y, dataSetIndex: dataSetIndex)
           }
-          
+
           if json["dataIndex"].int != nil {
             highlight.dataIndex = json["dataIndex"].intValue
           }
-          
+
           highlights.append(highlight)
         }
       }
     }
-    
+
     return highlights
   }
 }

--- a/lib/BarLineChartBase.js
+++ b/lib/BarLineChartBase.js
@@ -35,6 +35,10 @@ const iface = {
         })
       })
     }),
+    maxScale: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number
+    }),
     autoScaleMinMaxEnabled: PropTypes.bool,
     keepPositionOnRotation: PropTypes.bool,
 
@@ -60,13 +64,13 @@ const iface = {
     }),
     viewPortOffsets: PropTypes.shape({
       left: PropTypes.number,
-      top: PropTypes.number, 
+      top: PropTypes.number,
       right: PropTypes.number,
       bottom: PropTypes.number
     }),
     extraOffsets: PropTypes.shape({
       left: PropTypes.number,
-      top: PropTypes.number, 
+      top: PropTypes.number,
       right: PropTypes.number,
       bottom: PropTypes.number
     }),

--- a/react-native-charts-wrapper.podspec
+++ b/react-native-charts-wrapper.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.dependency 'React'
   s.dependency 'SwiftyJSON', '5.0'
-  s.dependency 'Charts', '5.0.0'
+  s.dependency 'DGCharts', '5.0.0'
 
 
 end

--- a/react-native-charts-wrapper.podspec
+++ b/react-native-charts-wrapper.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.dependency 'React'
   s.dependency 'SwiftyJSON', '5.0'
-  s.dependency 'Charts', '4.1.0'
+  s.dependency 'Charts', '5.0.0'
 
 
 end


### PR DESCRIPTION
Charts is deprecated as you can see here and we should use DGCharts instead

<img width="1187" alt="Screenshot 2023-10-06 at 11 54 06" src="https://github.com/wuxudong/react-native-charts-wrapper/assets/30073979/b2eda117-962c-4cc0-be35-e3f183645a19">

<img width="864" alt="Screenshot 2023-10-06 at 11 50 47" src="https://github.com/wuxudong/react-native-charts-wrapper/assets/30073979/da86188d-83f0-4f86-acac-30f921e6fe4d">