### PR TITLE
Render images instead of circles for data points in ScatterChart

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
@@ -65,14 +65,14 @@ public class ScatterDataExtract extends DataExtract<ScatterData, Entry> {
             if (map.hasKey("x")) {
                 x = (float) map.getDouble("x");
             }
-            entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));
+            // entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));
 
             if (map.hasKey("icon")) {
                 ReadableMap icon = map.getMap("icon");
                 ReadableMap bundle = icon.getMap("bundle");
                 int width = icon.getInt("width");
                 int height = icon.getInt("height");
-                entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height));
+                entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height), ConversionUtil.toMap(map));
 
             } else {
                 entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
@@ -12,7 +12,9 @@ import com.github.mikephil.charting.interfaces.datasets.IDataSet;
 import com.github.wuxudong.rncharts.utils.BridgeUtils;
 import com.github.wuxudong.rncharts.utils.ChartDataSetConfigUtils;
 import com.github.wuxudong.rncharts.utils.ConversionUtil;
+import com.github.wuxudong.rncharts.utils.DrawableUtils;
 
+import java.lang.Exception;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -64,6 +66,17 @@ public class ScatterDataExtract extends DataExtract<ScatterData, Entry> {
                 x = (float) map.getDouble("x");
             }
             entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));
+
+            if (map.hasKey("icon")) {
+                ReadableMap icon = map.getMap("icon");
+                ReadableMap bundle = icon.getMap("bundle");
+                int width = icon.getInt("width");
+                int height = icon.getInt("height");
+                entry = new Entry(x, (float) map.getDouble("y"), DrawableUtils.drawableFromUrl(bundle.getString("uri"), width, height));
+
+            } else {
+                entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));
+            }
         } else if (ReadableType.Number.equals(values.getType(index))) {
             entry = new Entry(x, (float) values.getDouble(index));
         } else {

--- a/ios/ReactNativeCharts/scatter/ScatterDataExtract.swift
+++ b/ios/ReactNativeCharts/scatter/ScatterDataExtract.swift
@@ -72,14 +72,14 @@ class ScatterDataExtract : DataExtract {
                     let bundle = icon["bundle"];
 
                     let uiImage = RCTConvert.uiImage(bundle.dictionaryObject);
-                    let width = CGFloat(icon["width"].numberValue)/4;
-                    let height = CGFloat(icon["height"].numberValue)/4;
+                    let width = CGFloat(icon["width"].numberValue)/2.5;
+                    let height = CGFloat(icon["height"].numberValue)/2.5;
 
                     if let image = uiImage {
                         let realIconImage = resizeImage(image: image, width: width, height: height);
-                        entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, icon: realIconImage);
+                        entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, icon: realIconImage, data: dict as AnyObject?);
                     } else {
-                        entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, icon: uiImage);
+                        entry = ChartDataEntry(x: x, y: dict["y"].doubleValue, icon: uiImage, data: dict as AnyObject?);
                     } 
 
                 } else {
@@ -117,7 +117,7 @@ class ScatterDataExtract : DataExtract {
       let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
 
       // Actually do the resizing to the rect using the ImageContext stuff
-      UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+      UIGraphicsBeginImageContextWithOptions(newSize, false, 0.0)
       image.draw(in: rect)
       let newImage = UIGraphicsGetImageFromCurrentImageContext()
       UIGraphicsEndImageContext()

--- a/lib/ChartDataConfig.js
+++ b/lib/ChartDataConfig.js
@@ -217,7 +217,12 @@ const scatterData = PropTypes.shape({
           PropTypes.shape({
             x: PropTypes.number,
             y: PropTypes.number.isRequired,
-            marker: PropTypes.string
+            marker: PropTypes.string,
+            icon: PropTypes.shape({
+              bundle: PropTypes.object,
+              width: PropTypes.number,
+              height: PropTypes.number
+            })
           }),
           PropTypes.number
         ])


### PR DESCRIPTION
Duplicate effort from https://github.com/wuxudong/react-native-charts-wrapper/pull/652 for scatter chart instead