### PR TITLE
Update swifty json to 5.0.2

### DIFF
--- a/react-native-charts-wrapper.podspec
+++ b/react-native-charts-wrapper.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
   s.dependency 'React'
-  s.dependency 'SwiftyJSON', '5.0'
+  s.dependency 'SwiftyJSON', '5.0.2'
   s.dependency 'DGCharts', '5.0.0'
 
 


### PR DESCRIPTION
Update Swifty Json to 5.0.2 to handle appstore invalid binary due to missing privacy info from SwifyJson library
ITMS -91061
https://github.com/SwiftyJSON/SwiftyJSON/issues/1170
https://developer.apple.com/forums/thread/774960
https://developer.apple.com/support/third-party-SDK-requirements